### PR TITLE
[MSHARED-866] don't throw a java.lang.Error when reading invalid or corrupt properties files

### DIFF
--- a/src/main/java/org/apache/maven/shared/utils/PropertyUtils.java
+++ b/src/main/java/org/apache/maven/shared/utils/PropertyUtils.java
@@ -47,12 +47,10 @@ public class PropertyUtils
 
     /**
      * @param url The URL which should be used to load the properties.
-     *
      * @return The loaded properties.
-     *
      * @deprecated As of 3.1.0, please use method {@link #loadOptionalProperties(java.net.URL)}. This method should not
-     * be used as it suppresses exceptions silently when loading properties fails and returns {@code null} instead of an
-     * empty {@code Properties} instance when the given {@code URL} is {@code null}.
+     *             be used as it suppresses exceptions silently when loading properties fails and returns {@code null}
+     *             instead of an empty {@code Properties} instance when the given {@code URL} is {@code null}.
      */
     @Deprecated
     public static java.util.Properties loadProperties( @Nonnull URL url )
@@ -70,12 +68,10 @@ public class PropertyUtils
 
     /**
      * @param file The file from which the properties will be loaded.
-     *
      * @return The loaded properties.
-     *
      * @deprecated As of 3.1.0, please use method {@link #loadOptionalProperties(java.io.File)}. This method should not
-     * be used as it suppresses exceptions silently when loading properties fails and returns {@code null} instead of an
-     * empty {@code Properties} instance when the given {@code File} is {@code null}.
+     *             be used as it suppresses exceptions silently when loading properties fails and returns {@code null}
+     *             instead of an empty {@code Properties} instance when the given {@code File} is {@code null}.
      */
     @Deprecated
     public static Properties loadProperties( @Nonnull File file )
@@ -93,11 +89,9 @@ public class PropertyUtils
 
     /**
      * @param is {@link InputStream}
-     *
      * @return The loaded properties.
-     *
      * @deprecated As of 3.1.0, please use method {@link #loadOptionalProperties(java.io.InputStream)}. This method
-     * should not be used as it suppresses exceptions silently when loading properties fails.
+     *             should not be used as it suppresses exceptions silently when loading properties fails.
      */
     @Deprecated
     public static Properties loadProperties( @Nullable InputStream is )
@@ -133,121 +127,98 @@ public class PropertyUtils
     /**
      * Loads {@code Properties} from a given {@code URL}.
      * <p>
-     * If the given {@code URL} is not {@code null}, it is asserted to represent a valid and loadable properties
-     * resource.
+     * If the given {@code URL} is {@code null} or the properties can't be read, an empty properties object is returned.
      * </p>
      *
-     * @param url The {@code URL} of the properties resource to load or {@code null}.
-     *
-     * @return The loaded properties or an empty {@code Properties} instance if {@code url} is {@code null}.
-     *
+     * @param url the {@code URL} of the properties resource to load or {@code null}
+     * @return the loaded properties or an empty {@code Properties} instance if properties fail to load
      * @since 3.1.0
      */
-    @Nonnull public static Properties loadOptionalProperties( final @Nullable URL url )
+    @Nonnull
+    public static Properties loadOptionalProperties( final @Nullable URL url )
     {
-        InputStream in = null;
-        try
-        {
-            final Properties properties = new Properties();
 
-            if ( url != null )
+        Properties properties = new Properties();
+        if ( url != null )
+        {
+            try ( InputStream in = url.openStream() )
             {
-                in = url.openStream();
                 properties.load( in );
-                in.close();
-                in = null;
             }
-
-            return properties;
+            catch ( IllegalArgumentException | IOException ex )
+            {
+                // ignore and return empty properties
+            }
         }
-        catch ( final IOException e )
-        {
-            throw new AssertionError( e );
-        }
-        finally
-        {
-            IOUtil.close( in );
-        }
+        return properties;
     }
 
     /**
      * Loads {@code Properties} from a given {@code File}.
      * <p>
-     * If the given {@code File} is not {@code null}, it is asserted to represent a valid and loadable properties
-     * resource.
+     * If the given {@code File} is {@code null} or the properties file can't be read, an empty properties object is
+     * returned.
      * </p>
      *
-     * @param file The {@code File} of the properties resource to load or {@code null}.
-     *
-     * @return The loaded properties or an empty {@code Properties} instance if {@code file} is {@code null}.
-     *
+     * @param file the {@code File} of the properties resource to load or {@code null}
+     * @return the loaded properties or an empty {@code Properties} instance if properties fail to load
      * @since 3.1.0
      */
-    @Nonnull public static Properties loadOptionalProperties( final @Nullable File file )
+    @Nonnull
+    public static Properties loadOptionalProperties( final @Nullable File file )
     {
-        InputStream in = null;
-        try
+        Properties properties = new Properties();
+        if ( file != null )
         {
-            final Properties properties = new Properties();
-
-            if ( file != null )
+            try ( InputStream in = new FileInputStream( file ) )
             {
-                in = new FileInputStream( file );
                 properties.load( in );
-                in.close();
-                in = null;
             }
+            catch ( IllegalArgumentException | IOException ex )
+            {
+                // ignore and return empty properties
+            }
+        }
 
-            return properties;
-        }
-        catch ( final IOException e )
-        {
-            throw new AssertionError( e );
-        }
-        finally
-        {
-            IOUtil.close( in );
-        }
+        return properties;
+
     }
 
     /**
      * Loads {@code Properties} from a given {@code InputStream}.
      * <p>
-     * If the given {@code InputStream} is not {@code null}, it is asserted to represent a valid and loadable properties
-     * resource.
+     * If the given {@code InputStream} is {@code null} or the properties can't be read, an empty properties object is
+     * returned.
      * </p>
      *
-     * @param inputStream The {@code InputStream} of the properties resource to load or {@code null}.
-     *
-     * @return The loaded properties or an empty {@code Properties} instance if {@code inputStream} is {@code null}.
-     *
+     * @param inputStream the properties resource to load or {@code null}
+     * @return the loaded properties or an empty {@code Properties} instance if properties fail to load
      * @since 3.1.0
      */
-    @Nonnull public static Properties loadOptionalProperties( final @Nullable InputStream inputStream )
+    @Nonnull
+    public static Properties loadOptionalProperties( final @Nullable InputStream inputStream )
     {
-        InputStream in = null;
-        try
-        {
-            final Properties properties = new Properties();
 
-            if ( inputStream != null )
+        Properties properties = new Properties();
+
+        if ( inputStream != null )
+        {
+            try
             {
-                in = inputStream;
-                properties.load( in );
-                in.close();
-                in = null;
+                properties.load( inputStream );
             }
+            catch ( IllegalArgumentException | IOException ex )
+            {
+                // ignore and return empty properties
+            }
+            finally
+            {
+                IOUtil.close( inputStream );
+            }
+        }
 
-            return properties;
-        }
-        catch ( final IOException e )
-        {
-            throw new AssertionError( e );
-        }
-        finally
-        {
-            IOUtil.close( in );
-        }
+        return properties;
+
     }
 
 }

--- a/src/test/java/org/apache/maven/shared/utils/PropertyUtilsTest.java
+++ b/src/test/java/org/apache/maven/shared/utils/PropertyUtilsTest.java
@@ -22,8 +22,10 @@ package org.apache.maven.shared.utils;
 import java.io.ByteArrayInputStream;
 import java.io.File;
 import java.io.FileOutputStream;
+import java.io.IOException;
 import java.io.InputStream;
 import java.io.OutputStream;
+import java.io.UnsupportedEncodingException;
 import java.lang.annotation.ElementType;
 import java.lang.annotation.Retention;
 import java.lang.annotation.RetentionPolicy;
@@ -38,7 +40,7 @@ import org.junit.rules.TemporaryFolder;
 
 import static org.hamcrest.CoreMatchers.is;
 import static org.hamcrest.CoreMatchers.nullValue;
-import static org.junit.Assert.assertThat;
+import static org.hamcrest.MatcherAssert.assertThat;
 
 public class PropertyUtilsTest
 {
@@ -66,6 +68,15 @@ public class PropertyUtilsTest
         throws Exception
     {
         assertThat( PropertyUtils.loadOptionalProperties( (InputStream) null ), is( new Properties() ) );
+    }
+    
+
+    @Test
+    public void loadOptionalProperties_ioException()
+        throws Exception
+    {
+        URL url = new URL( "https://nonesuch12344.foo.bar.com" );
+        assertThat( PropertyUtils.loadOptionalProperties( url ), is( new Properties() ) );
     }
 
     @Test
@@ -137,8 +148,7 @@ public class PropertyUtilsTest
 
     @Test
     @SuppressWarnings( "deprecation" )
-    public void loadValidInputStream()
-        throws Exception
+    public void loadValidInputStream() throws UnsupportedEncodingException
     {
         Properties value = new Properties();
         value.setProperty( "a", "b" );
@@ -154,8 +164,7 @@ public class PropertyUtilsTest
     @Test
     @NeedsTemporaryFolder
     @SuppressWarnings( "deprecation" )
-    public void loadValidFile()
-        throws Exception
+    public void loadValidFile() throws IOException
     {
         OutputStream out = null;
         try
@@ -179,8 +188,7 @@ public class PropertyUtilsTest
     @Test
     @NeedsTemporaryFolder
     @SuppressWarnings( "deprecation" )
-    public void loadValidURL()
-        throws Exception
+    public void loadValidURL() throws IOException
     {
         OutputStream out = null;
         try


### PR DESCRIPTION
@michael-o 