### PR TITLE
[MSHARED-884] - Don't always overwrite filtered resources

### DIFF
--- a/src/main/java/org/apache/maven/shared/utils/io/FileUtils.java
+++ b/src/main/java/org/apache/maven/shared/utils/io/FileUtils.java
@@ -1810,10 +1810,16 @@ public class FileUtils
                                  @Nullable FilterWrapper[] wrappers, boolean overwrite )
         throws IOException
     {
-        if ( wrappers != null && wrappers.length > 0 )
+        if ( wrappers == null || wrappers.length == 0 )
         {
-            
-            if ( encoding == null || encoding.isEmpty() ) 
+            if ( overwrite || to.lastModified() < from.lastModified() )
+            {
+                copyFile( from, to );
+            }
+        }
+        else
+        {
+            if ( encoding == null || encoding.isEmpty() )
             {
                 encoding = Charset.defaultCharset().name();
             }
@@ -1831,13 +1837,6 @@ public class FileUtils
                 }
 
                 IOUtil.copy( wrapped, fileWriter );
-            }
-        }
-        else
-        {
-            if ( to.lastModified() < from.lastModified() || overwrite )
-            {
-                copyFile( from, to );
             }
         }
     }

--- a/src/main/java/org/apache/maven/shared/utils/io/FileUtils.java
+++ b/src/main/java/org/apache/maven/shared/utils/io/FileUtils.java
@@ -40,6 +40,7 @@ import java.io.RandomAccessFile;
 import java.io.Reader;
 import java.io.Writer;
 import java.net.URL;
+import java.nio.Buffer;
 import java.nio.ByteBuffer;
 import java.nio.CharBuffer;
 import java.nio.channels.FileChannel;
@@ -1868,7 +1869,7 @@ public class FileUtils
                         int n;
                         while ( -1 != ( n = wrapped.read( newChars ) ) )
                         {
-                            newChars.flip();
+                            ( ( Buffer ) newChars ).flip();
 
                             coderResult = encoder.encode( newChars, newBytes, n != 0 );
                             if ( coderResult.isError() )
@@ -1876,13 +1877,13 @@ public class FileUtils
                                 coderResult.throwException();
                             }
 
-                            newBytes.flip();
+                            ( ( Buffer ) newBytes ).flip();
 
                             if ( !writing )
                             {
                                 existingRead = existing.read( existingBytes.array(), 0, newBytes.remaining() );
-                                existingBytes.position( existingRead );
-                                existingBytes.flip();
+                                ( ( Buffer ) existingBytes ).position( existingRead );
+                                ( ( Buffer ) existingBytes ).flip();
 
                                 if ( newBytes.compareTo( existingBytes ) != 0 )
                                 {
@@ -1899,9 +1900,9 @@ public class FileUtils
                                 existing.write( newBytes.array(), 0, newBytes.remaining() );
                             }
 
-                            newChars.clear();
-                            newBytes.clear();
-                            existingBytes.clear();
+                            ( ( Buffer ) newChars ).clear();
+                            ( ( Buffer ) newBytes ).clear();
+                            ( ( Buffer ) existingBytes ).clear();
                         }
 
                         if ( existing.length() > existing.getFilePointer() )

--- a/src/main/java/org/apache/maven/shared/utils/io/FileUtils.java
+++ b/src/main/java/org/apache/maven/shared/utils/io/FileUtils.java
@@ -30,12 +30,9 @@ import java.io.BufferedReader;
 import java.io.File;
 import java.io.FileInputStream;
 import java.io.FileOutputStream;
-import java.io.FileReader;
 import java.io.IOException;
 import java.io.InputStream;
-import java.io.InputStreamReader;
 import java.io.OutputStream;
-import java.io.OutputStreamWriter;
 import java.io.RandomAccessFile;
 import java.io.Reader;
 import java.io.Writer;
@@ -281,7 +278,8 @@ public class FileUtils
 
         StringBuilder buf = new StringBuilder();
 
-        try ( Reader reader = new InputStreamReader( new FileInputStream( file ), charset ) )
+
+        try ( Reader reader = Files.newBufferedReader( file.toPath(), charset ) )
         {
             int count;
             char[] b = new char[512];
@@ -383,7 +381,7 @@ public class FileUtils
     {
         Charset charset = charset( encoding );
 
-        try ( Writer writer = new OutputStreamWriter( new FileOutputStream( file ), charset ) )
+        try ( Writer writer = Files.newBufferedWriter( file.toPath(), charset ) )
         {
             writer.write( data );
         }
@@ -416,7 +414,7 @@ public class FileUtils
     {
         Charset charset = charset( encoding );
 
-        try ( Writer writer = new OutputStreamWriter( new FileOutputStream( file ), charset ) )
+        try ( Writer writer = Files.newBufferedWriter( file.toPath(), charset ) )
         {
             for ( int i = 0; data != null && i < data.length; i++ )
             {
@@ -1814,8 +1812,7 @@ public class FileUtils
             Charset charset = charset( encoding );
 
             // buffer so it isn't reading a byte at a time!
-            try ( Reader fileReader =
-                    new BufferedReader( new InputStreamReader( new FileInputStream( from ), charset ) ) )
+            try ( Reader fileReader = Files.newBufferedReader( from.toPath(), charset ) )
             {
                 Reader wrapped = fileReader;
                 for ( FilterWrapper wrapper : wrappers )
@@ -1825,7 +1822,7 @@ public class FileUtils
 
                 if ( overwrite || !to.exists() )
                 {
-                    try ( Writer fileWriter = new OutputStreamWriter( new FileOutputStream( to ), charset ) )
+                    try ( Writer fileWriter = Files.newBufferedWriter( to.toPath(), charset ) )
                     {
                         IOUtil.copy( wrapped, fileWriter );
                     }
@@ -1912,7 +1909,7 @@ public class FileUtils
 
         if ( file.exists() )
         {
-            try ( BufferedReader reader = new BufferedReader( new FileReader( file ) ) )
+            try ( BufferedReader reader = Files.newBufferedReader( file.toPath(), Charset.defaultCharset() ) )
             {
                 for ( String line = reader.readLine(); line != null; line = reader.readLine() )
                 {

--- a/src/main/java/org/apache/maven/shared/utils/io/FileUtils.java
+++ b/src/main/java/org/apache/maven/shared/utils/io/FileUtils.java
@@ -277,13 +277,11 @@ public class FileUtils
     @Nonnull public static String fileRead( @Nonnull File file, @Nullable String encoding )
         throws IOException
     {
-        StringBuilder buf = new StringBuilder();   
-        if ( encoding == null ) 
-        {
-            encoding = Charset.defaultCharset().name();
-        }
+        Charset charset = charset( encoding );
 
-        try ( Reader reader = new InputStreamReader( new FileInputStream( file ), encoding ) )
+        StringBuilder buf = new StringBuilder();
+
+        try ( Reader reader = new InputStreamReader( new FileInputStream( file ), charset ) )
         {
             int count;
             char[] b = new char[512];
@@ -335,15 +333,11 @@ public class FileUtils
     public static void fileAppend( @Nonnull String fileName, @Nullable String encoding, @Nonnull String data )
         throws IOException
     {
-        
-        if ( encoding == null ) 
-        {
-            encoding = Charset.defaultCharset().name();
-        }
-        
+        Charset charset = charset( encoding );
+
         try ( OutputStream out = new FileOutputStream( fileName, true ) )
         {
-          out.write( data.getBytes( encoding ) );
+          out.write( data.getBytes( charset ) );
         }
     }
 
@@ -387,13 +381,9 @@ public class FileUtils
     public static void fileWrite( @Nonnull File file, @Nullable String encoding, @Nonnull String data )
         throws IOException
     {
-        
-        if ( encoding == null ) 
-        {
-            encoding = Charset.defaultCharset().name();
-        }
+        Charset charset = charset( encoding );
 
-        try ( Writer writer = new OutputStreamWriter( new FileOutputStream( file ), encoding ) ) 
+        try ( Writer writer = new OutputStreamWriter( new FileOutputStream( file ), charset ) )
         {
             writer.write( data );
         }
@@ -424,13 +414,9 @@ public class FileUtils
     public static void fileWriteArray( @Nonnull File file, @Nullable String encoding, @Nullable String... data )
         throws IOException
     {
-        
-        if ( encoding == null ) 
-        {
-            encoding = Charset.defaultCharset().name();
-        }
+        Charset charset = charset( encoding );
 
-        try ( Writer writer = new OutputStreamWriter( new FileOutputStream( file ), encoding ) )
+        try ( Writer writer = new OutputStreamWriter( new FileOutputStream( file ), charset ) )
         {
             for ( int i = 0; data != null && i < data.length; i++ )
             {
@@ -1825,14 +1811,11 @@ public class FileUtils
         }
         else
         {
-            if ( encoding == null || encoding.isEmpty() )
-            {
-                encoding = Charset.defaultCharset().name();
-            }
+            Charset charset = charset( encoding );
 
             // buffer so it isn't reading a byte at a time!
             try ( Reader fileReader =
-                    new BufferedReader( new InputStreamReader( new FileInputStream( from ), encoding ) ) )
+                    new BufferedReader( new InputStreamReader( new FileInputStream( from ), charset ) ) )
             {
                 Reader wrapped = fileReader;
                 for ( FilterWrapper wrapper : wrappers )
@@ -1842,14 +1825,14 @@ public class FileUtils
 
                 if ( overwrite || !to.exists() )
                 {
-                    try ( Writer fileWriter = new OutputStreamWriter( new FileOutputStream( to ), encoding ) )
+                    try ( Writer fileWriter = new OutputStreamWriter( new FileOutputStream( to ), charset ) )
                     {
                         IOUtil.copy( wrapped, fileWriter );
                     }
                 }
                 else
                 {
-                    CharsetEncoder encoder = Charset.forName( encoding ).newEncoder();
+                    CharsetEncoder encoder = charset.newEncoder();
 
                     int totalBufferSize = FILE_COPY_BUFFER_SIZE;
 
@@ -1944,6 +1927,23 @@ public class FileUtils
 
         return lines;
 
+    }
+
+    /**
+     * Returns the named charset or the default charset.
+     * @param encoding the name or alias of the charset, null or empty
+     * @return A charset object for the named or default charset.
+     */
+    private static Charset charset( String encoding )
+    {
+        if ( encoding == null || encoding.isEmpty() )
+        {
+            return Charset.defaultCharset();
+        }
+        else
+        {
+            return Charset.forName( encoding );
+        }
     }
 
     /**

--- a/src/test/java/org/apache/maven/shared/utils/io/FileUtilsTest.java
+++ b/src/test/java/org/apache/maven/shared/utils/io/FileUtilsTest.java
@@ -45,6 +45,7 @@ import java.util.HashMap;
 import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
+import java.util.concurrent.TimeUnit;
 
 /*
  * Licensed to the Apache Software Foundation (ASF) under one
@@ -449,16 +450,14 @@ public class FileUtilsTest
             testFile1.lastModified() == destination.lastModified());*/
     }
 
-    private static long MILLIS_PER_DAY = 24 * 60 * 60 * 1000L;
-
     /** A time today, rounded down to the previous minute */
-    private static long MODIFIED_TODAY = (System.currentTimeMillis() / 60_000) * 60_000;
+    private static long MODIFIED_TODAY = (System.currentTimeMillis() / TimeUnit.MINUTES.toMillis( 1 )) * TimeUnit.MINUTES.toMillis( 1 );
 
     /** A time yesterday, rounded down to the previous minute */
-    private static long MODIFIED_YESTERDAY = MODIFIED_TODAY - MILLIS_PER_DAY;
+    private static long MODIFIED_YESTERDAY = MODIFIED_TODAY - TimeUnit.DAYS.toMillis( 1 );
 
     /** A time last week, rounded down to the previous minute */
-    private static long MODIFIED_LAST_WEEK = MODIFIED_TODAY - MILLIS_PER_DAY * 7;
+    private static long MODIFIED_LAST_WEEK = MODIFIED_TODAY - TimeUnit.DAYS.toMillis( 7 );
 
     @Test
     public void copyFileWithNoFiltersAndNoDestination()

--- a/src/test/java/org/apache/maven/shared/utils/io/FileUtilsTest.java
+++ b/src/test/java/org/apache/maven/shared/utils/io/FileUtilsTest.java
@@ -651,7 +651,7 @@ public class FileUtilsTest
     }
 
     @Test
-    public void copyFileWithFilteringAndNewerDestination()
+    public void copyFileWithFilteringAndNewerDestinationButModifiedContent()
             throws Exception
     {
         File from = write(
@@ -672,6 +672,32 @@ public class FileUtilsTest
             to.lastModified() >= MODIFIED_TODAY
         );
         assertFileContent( to, "Hello Bob!" );
+    }
+
+    @Test
+    public void copyFileWithFilteringAndNewerDestinationAndMatchingContent()
+            throws Exception
+    {
+        File from = write(
+            "from.txt",
+            MODIFIED_LAST_WEEK,
+            "Hello ${name}!"
+        );
+        File to = write(
+            "to.txt",
+            MODIFIED_YESTERDAY,
+            "Hello Bob!"
+        );
+
+        String encoding = null;
+
+        FileUtils.copyFile( from, to, null, wrappers( "name", "Bob" ) );
+
+        assertFileContent( to, "Hello Bob!" );
+        assertTrue(
+            "to.txt content should be unchanged and have been left alone",
+            to.lastModified() < MODIFIED_TODAY
+        );
     }
 
     private FileUtils.FilterWrapper[] wrappers( String key, String value )


### PR DESCRIPTION
- Added unit tests for `FileUtils.copyFile()` methods using `FilterWrapper`
- When filtering and _potentially_ overwriting an existing file:
  - Open the existing file as a `RandomAccessFile`
  - Encode each buffer of content
  - Compare encoded buffer with a matching buffer from the existing file
  - If different then overwrite the remainder of the file  
- Added unit tests to demonstrate that lastModified date is only updated when the content changes.
- Rudimentary performance tests with various source sizes show no significant impact:

  Source Size | Avg Millis (Old) | Avg Millis (New)
  -- | -- | --
  100 MB | 6034 | 5940
  1 MB | 54 | 56
  10 KB | 1 | 8

Relates to MSHARED-884