### PR TITLE
[MSHARED-860] Deprecate unnecessary Java7Support

### DIFF
--- a/src/main/java/org/apache/maven/shared/utils/io/DirectoryScanner.java
+++ b/src/main/java/org/apache/maven/shared/utils/io/DirectoryScanner.java
@@ -21,6 +21,7 @@ package org.apache.maven.shared.utils.io;
 
 import java.io.File;
 import java.io.IOException;
+import java.nio.file.Files;
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.HashSet;
@@ -902,13 +903,7 @@ public class DirectoryScanner
     boolean isSymbolicLink( final File parent, final String name )
         throws IOException
     {
-        if ( Java7Support.isAtLeastJava7() )
-        {
-            return Java7Support.isSymLink( parent );
-        }
-        final File resolvedParent = new File( parent.getCanonicalPath() );
-        final File toTest = new File( resolvedParent, name );
-        return !toTest.getAbsolutePath().equals( toTest.getCanonicalPath() );
+        return Files.isSymbolicLink( parent.toPath() );
     }
 
     private void setupDefaultFilters()

--- a/src/main/java/org/apache/maven/shared/utils/io/FileUtils.java
+++ b/src/main/java/org/apache/maven/shared/utils/io/FileUtils.java
@@ -765,10 +765,10 @@ public class FileUtils
             final String message = "File " + source + " does not exist";
             throw new IOException( message );
         }
-        if ( Java7Support.isAtLeastJava7() && Java7Support.isSymLink( source ) )
+        if ( Files.isSymbolicLink( source.toPath() ) )
         {
-            File target = Java7Support.readSymbolicLink( source );
-            Java7Support.createSymbolicLink( destination, target );
+            File target = Files.readSymbolicLink( source.toPath() ).toFile();
+            createSymbolicLink( destination, target );
             return;
         }
 
@@ -1102,17 +1102,7 @@ public class FileUtils
     public static void delete( @Nonnull File file )
         throws IOException
     {
-        if ( Java7Support.isAtLeastJava7() )
-        {
-            Java7Support.delete( file );
-        }
-        else
-        {
-            if ( !file.delete() )
-            {
-                throw new IOException( "Could not delete " + file.getName() );
-            }
-        }
+        Files.delete( file.toPath() );
     }
 
     /**
@@ -1121,21 +1111,14 @@ public class FileUtils
      */
     public static boolean deleteLegacyStyle( @Nonnull File file )
     {
-        if ( Java7Support.isAtLeastJava7() )
+        try
         {
-            try
-            {
-                Java7Support.delete( file );
-                return true;
-            }
-            catch ( IOException e )
-            {
-                return false;
-            }
+            Files.delete( file.toPath() );
+            return true;
         }
-        else
+        catch ( IOException e )
         {
-            return file.delete();
+            return false;
         }
     }
 
@@ -1935,11 +1918,7 @@ public class FileUtils
     public static boolean isSymbolicLink( @Nonnull final File file )
         throws IOException
     {
-        if ( Java7Support.isAtLeastJava7() )
-        {
-            return Java7Support.isSymLink( file );
-        }
-        return isSymbolicLinkLegacy( file );
+        return Files.isSymbolicLink( file.toPath() );
     }
 
     /**
@@ -1954,7 +1933,7 @@ public class FileUtils
     public static boolean isSymbolicLinkForSure( @Nonnull final File file )
         throws IOException
     {
-        return Java7Support.isAtLeastJava7() && Java7Support.isSymLink( file );
+        return Files.isSymbolicLink( file.toPath() );
     }
 
     /**

--- a/src/main/java/org/apache/maven/shared/utils/io/FileUtils.java
+++ b/src/main/java/org/apache/maven/shared/utils/io/FileUtils.java
@@ -41,6 +41,7 @@ import java.io.Writer;
 import java.net.URL;
 import java.nio.channels.FileChannel;
 import java.nio.charset.Charset;
+import java.nio.file.Files;
 import java.security.SecureRandom;
 import java.text.DecimalFormat;
 import java.util.ArrayList;
@@ -1981,4 +1982,19 @@ public class FileUtils
         return !file.getAbsolutePath().equals( canonical.getPath() );
     }
 
+    /**
+     * @param symlink The link name.
+     * @param target The target.
+     * @return The linked file.
+     * @throws IOException in case of an error.
+     */
+    @Nonnull public static File createSymbolicLink( @Nonnull File symlink,  @Nonnull File target )
+            throws IOException
+    {
+        if ( !Files.exists( symlink.toPath() ) )
+        {
+            return Files.createSymbolicLink( symlink.toPath(), target.toPath() ).toFile();
+        }
+        return symlink;
+    }
 }

--- a/src/main/java/org/apache/maven/shared/utils/io/Java7Support.java
+++ b/src/main/java/org/apache/maven/shared/utils/io/Java7Support.java
@@ -28,7 +28,10 @@ import java.nio.file.Files;
  * Java7 feature detection
  *
  * @author Kristian Rosenvold
+ *
+ * @deprecated no longer needed, prefer to use {@link java.nio.file.Files} methods directly.
  */
+@Deprecated
 public class Java7Support
 {
     /**

--- a/src/main/java/org/apache/maven/shared/utils/io/Java7Support.java
+++ b/src/main/java/org/apache/maven/shared/utils/io/Java7Support.java
@@ -22,9 +22,7 @@ package org.apache.maven.shared.utils.io;
 import javax.annotation.Nonnull;
 import java.io.File;
 import java.io.IOException;
-import java.lang.reflect.Array;
-import java.lang.reflect.InvocationTargetException;
-import java.lang.reflect.Method;
+import java.nio.file.Files;
 
 /**
  * Java7 feature detection
@@ -33,81 +31,14 @@ import java.lang.reflect.Method;
  */
 public class Java7Support
 {
-
-    private static final boolean IS_JAVA7;
-
-    private static Method isSymbolicLink;
-
-    private static Method delete;
-
-    private static Method toPath;
-
-    private static Method exists;
-
-    private static Method toFile;
-
-    private static Method readSymlink;
-
-    private static Method createSymlink;
-
-    private static Object emptyLinkOpts;
-
-    private static Object emptyFileAttributes;
-
-    static
-    {
-        boolean isJava7x = true;
-        try
-        {
-            ClassLoader cl = Thread.currentThread().getContextClassLoader();
-            Class<?> files = cl.loadClass( "java.nio.file.Files" );
-            Class<?> path = cl.loadClass( "java.nio.file.Path" );
-            Class<?> fa = cl.loadClass( "java.nio.file.attribute.FileAttribute" );
-            Class<?> linkOption = cl.loadClass( "java.nio.file.LinkOption" );
-            isSymbolicLink = files.getMethod( "isSymbolicLink", path );
-            delete = files.getMethod( "delete", path );
-            readSymlink = files.getMethod( "readSymbolicLink", path );
-
-            emptyFileAttributes = Array.newInstance( fa, 0 );
-            final Object o = emptyFileAttributes;
-            createSymlink = files.getMethod( "createSymbolicLink", path, path, o.getClass() );
-            emptyLinkOpts = Array.newInstance( linkOption, 0 );
-            exists = files.getMethod( "exists", path, emptyLinkOpts.getClass() );
-            toPath = File.class.getMethod( "toPath" );
-            toFile = path.getMethod( "toFile" );
-        }
-        catch ( ClassNotFoundException e )
-        {
-            isJava7x = false;
-        }
-        catch ( NoSuchMethodException e )
-        {
-            isJava7x = false;
-        }
-        IS_JAVA7 = isJava7x;
-    }
-
     /**
      * @param file The file to check for being a symbolic link.
      * @return true if the file is a symlink false otherwise.
      */
     public static boolean isSymLink( @Nonnull File file )
     {
-        try
-        {
-            Object path = toPath.invoke( file );
-            return (Boolean) isSymbolicLink.invoke( null, path );
-        }
-        catch ( IllegalAccessException e )
-        {
-            throw new RuntimeException( e );
-        }
-        catch ( InvocationTargetException e )
-        {
-            throw new RuntimeException( e );
-        }
+        return Files.isSymbolicLink( file.toPath() );
     }
-
 
     /**
      * @param symlink The sym link.
@@ -117,22 +48,8 @@ public class Java7Support
     @Nonnull public static File readSymbolicLink( @Nonnull File symlink )
         throws IOException
     {
-        try
-        {
-            Object path = toPath.invoke( symlink );
-            Object resultPath =  readSymlink.invoke( null, path );
-            return (File) toFile.invoke( resultPath );
-        }
-        catch ( IllegalAccessException e )
-        {
-            throw new RuntimeException( e );
-        }
-        catch ( InvocationTargetException e )
-        {
-            throw new RuntimeException( e );
-        }
+        return Files.readSymbolicLink( symlink.toPath() ).toFile();
     }
-
 
     /**
      * @param file The file to check.
@@ -142,21 +59,7 @@ public class Java7Support
     public static boolean exists( @Nonnull File file )
         throws IOException
     {
-        try
-        {
-            Object path = toPath.invoke( file );
-            final Object invoke = exists.invoke( null, path, emptyLinkOpts );
-            return (Boolean) invoke;
-        }
-        catch ( IllegalAccessException e )
-        {
-            throw new RuntimeException( e );
-        }
-        catch ( InvocationTargetException e )
-        {
-            throw (RuntimeException) e.getTargetException();
-        }
-
+        return Files.exists( file.toPath() );
     }
 
     /**
@@ -168,40 +71,13 @@ public class Java7Support
     @Nonnull public static File createSymbolicLink( @Nonnull File symlink,  @Nonnull File target )
         throws IOException
     {
-        try
+        if ( !exists( symlink ) )
         {
-            if ( !exists( symlink ) )
-            {
-                Object link = toPath.invoke( symlink );
-                Object path = createSymlink.invoke( null, link, toPath.invoke( target ), emptyFileAttributes );
-                return (File) toFile.invoke( path );
-            }
-            return symlink;
+            return Files.createSymbolicLink( symlink.toPath(), target.toPath() ).toFile();
         }
-        catch ( IllegalAccessException e )
-        {
-            throw new RuntimeException( e );
-        }
-        catch ( InvocationTargetException e )
-        {
-            final Throwable targetException = e.getTargetException();
-            if ( targetException instanceof IOException )
-            {
-                throw (IOException) targetException;
-            }
-            else if ( targetException instanceof RuntimeException )
-            {
-                // java.lang.UnsupportedOperationException: Symbolic links not supported on this operating system
-                // java.lang.SecurityException: denies certain permissions see Javadoc
-                throw ( RuntimeException ) targetException;
-            }
-            else
-            {
-                throw new IOException( targetException.getClass() + ": " + targetException.getLocalizedMessage() );
-            }
-        }
-
+        return symlink;
     }
+
     /**
      * Performs a nio delete
      * @param file the file to delete
@@ -210,19 +86,7 @@ public class Java7Support
     public static void delete( @Nonnull File file )
         throws IOException
     {
-        try
-        {
-            Object path = toPath.invoke( file );
-            delete.invoke( null, path );
-        }
-        catch ( IllegalAccessException e )
-        {
-            throw new RuntimeException( e );
-        }
-        catch ( InvocationTargetException e )
-        {
-            throw (IOException) e.getTargetException();
-        }
+        Files.delete( file.toPath() );
     }
 
     /**
@@ -230,7 +94,7 @@ public class Java7Support
      */
     public static boolean isJava7()
     {
-        return IS_JAVA7;
+        return true;
     }
 
     /**
@@ -238,7 +102,6 @@ public class Java7Support
      */
     public static boolean isAtLeastJava7()
     {
-        return IS_JAVA7;
+        return true;
     }
-
 }

--- a/src/main/java/org/apache/maven/shared/utils/io/Java7Support.java
+++ b/src/main/java/org/apache/maven/shared/utils/io/Java7Support.java
@@ -71,11 +71,7 @@ public class Java7Support
     @Nonnull public static File createSymbolicLink( @Nonnull File symlink,  @Nonnull File target )
         throws IOException
     {
-        if ( !exists( symlink ) )
-        {
-            return Files.createSymbolicLink( symlink.toPath(), target.toPath() ).toFile();
-        }
-        return symlink;
+        return FileUtils.createSymbolicLink( symlink, target );
     }
 
     /**

--- a/src/test/java/org/apache/maven/shared/utils/io/DirectoryScannerTest.java
+++ b/src/test/java/org/apache/maven/shared/utils/io/DirectoryScannerTest.java
@@ -153,7 +153,6 @@ public class DirectoryScannerTest
         throws IOException
     {
         assumeFalse( Os.isFamily( Os.FAMILY_WINDOWS ) );
-        assumeTrue( Java7Support.isAtLeastJava7() );
 
         File testDir = SymlinkTestSetup.createStandardSymlinkTestDir( new File( "target/test/symlinkTestCase" ) );
 
@@ -191,7 +190,6 @@ public class DirectoryScannerTest
         throws IOException
     {
         assumeFalse( Os.isFamily( Os.FAMILY_WINDOWS ) );
-        assumeTrue( Java7Support.isAtLeastJava7() );
 
         DirectoryScanner ds = new DirectoryScanner();
         File testDir = SymlinkTestSetup.createStandardSymlinkTestDir( new File( "target/test/symlinkTestCase" ) );

--- a/src/test/java/org/apache/maven/shared/utils/io/FileUtilsTest.java
+++ b/src/test/java/org/apache/maven/shared/utils/io/FileUtilsTest.java
@@ -4,7 +4,9 @@ import static org.hamcrest.CoreMatchers.containsString;
 import static org.hamcrest.CoreMatchers.hasItems;
 import static org.hamcrest.CoreMatchers.is;
 import static org.hamcrest.CoreMatchers.not;
+import static org.hamcrest.CoreMatchers.startsWith;
 import static org.hamcrest.MatcherAssert.assertThat;
+import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertTrue;
 import static org.junit.Assert.fail;
@@ -1437,6 +1439,22 @@ public class FileUtilsTest
     {
         assumeThat( File.separatorChar, is( '/' ) );
         assertThat( FileUtils.extension( "/test/foo.bar.txt" ), is( "txt" ) );
+    }
+
+    @Test
+    public void createAndReadSymlink()
+        throws Exception
+    {
+        assumeThat( System.getProperty( "os.name" ), not( startsWith( "Windows" ) ) );
+        File file = new File( "target/fzz" );
+        if ( Java7Support.isAtLeastJava7() )
+        {
+            FileUtils.createSymbolicLink(  file, new File("../target") );
+
+            final File file1 = Java7Support.readSymbolicLink( file );
+            assertEquals( "target", file1.getName());
+            Java7Support.delete(  file );
+        }
     }
 
     //// constants for testing

--- a/src/test/java/org/apache/maven/shared/utils/io/FileUtilsTest.java
+++ b/src/test/java/org/apache/maven/shared/utils/io/FileUtilsTest.java
@@ -23,6 +23,7 @@ import java.io.IOException;
 import java.io.InputStream;
 import java.io.OutputStream;
 import java.net.URL;
+import java.nio.file.Files;
 import java.util.Arrays;
 import java.util.HashSet;
 import java.util.List;
@@ -444,7 +445,6 @@ public class FileUtilsTest
     public void copyFileThatIsSymlink()
         throws Exception
     {
-        assumeTrue( Java7Support.isAtLeastJava7() );
         assumeFalse( Os.isFamily( Os.FAMILY_WINDOWS ) );
 
         File destination = new File( tempFolder.getRoot(), "symCopy.txt" );
@@ -452,7 +452,8 @@ public class FileUtilsTest
         File testDir = SymlinkTestSetup.createStandardSymlinkTestDir( new File( "target/test/symlinkCopy" ) );
 
         FileUtils.copyFile( new File( testDir, "symR" ), destination );
-        assertTrue( Java7Support.isSymLink(  destination ));
+
+        assertTrue( Files.isSymbolicLink( destination.toPath() ) );
     }
 
 
@@ -1447,14 +1448,11 @@ public class FileUtilsTest
     {
         assumeThat( System.getProperty( "os.name" ), not( startsWith( "Windows" ) ) );
         File file = new File( "target/fzz" );
-        if ( Java7Support.isAtLeastJava7() )
-        {
-            FileUtils.createSymbolicLink(  file, new File("../target") );
+        FileUtils.createSymbolicLink(  file, new File("../target") );
 
-            final File file1 = Java7Support.readSymbolicLink( file );
-            assertEquals( "target", file1.getName());
-            Java7Support.delete(  file );
-        }
+        final File file1 = Files.readSymbolicLink( file.toPath() ).toFile();
+        assertEquals( "target", file1.getName() );
+        Files.delete( file.toPath() );
     }
 
     //// constants for testing

--- a/src/test/java/org/apache/maven/shared/utils/io/Java7SupportTest.java
+++ b/src/test/java/org/apache/maven/shared/utils/io/Java7SupportTest.java
@@ -43,20 +43,4 @@ public class Java7SupportTest
         }
     }
 
-    @Test
-    public void createAndReadSymlink()
-        throws Exception
-    {
-        assumeThat( System.getProperty( "os.name" ), not( startsWith( "Windows" ) ) );
-        File file = new File( "target/fzz" );
-        if ( Java7Support.isAtLeastJava7() )
-        {
-            Java7Support.createSymbolicLink(  file, new File("../target") );
-
-            final File file1 = Java7Support.readSymbolicLink( file );
-            assertEquals( "target", file1.getName());
-            Java7Support.delete(  file );
-        }
-    }
-
 }

--- a/src/test/java/org/apache/maven/shared/utils/io/Java7SupportTest.java
+++ b/src/test/java/org/apache/maven/shared/utils/io/Java7SupportTest.java
@@ -27,7 +27,6 @@ import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
 import static org.junit.Assume.assumeThat;
 import static org.hamcrest.CoreMatchers.not;
-import static org.hamcrest.CoreMatchers.startsWith;
 
 public class Java7SupportTest
 {
@@ -35,12 +34,8 @@ public class Java7SupportTest
     public void testIsSymLink()
         throws Exception
     {
-
         File file = new File( "." );
-        if ( Java7Support.isAtLeastJava7() )
-        {
-            assertFalse( Java7Support.isSymLink( file ) );
-        }
+        assertFalse( Java7Support.isSymLink( file ) );
     }
 
 }

--- a/src/test/java/org/apache/maven/shared/utils/io/SymlinkTestSetup.java
+++ b/src/test/java/org/apache/maven/shared/utils/io/SymlinkTestSetup.java
@@ -51,14 +51,12 @@ public class SymlinkTestSetup
         write( new File( srcDir, "fileX.txt" ), "FileX payload", StandardCharsets.UTF_8 );
         // todo: set file attributes (not used here)
 
-        Java7Support.createSymbolicLink( new File( srcDir, "symDir" ), new File( "targetDir" ) );
-        Java7Support.createSymbolicLink( new File( srcDir, "symLinkToDirOnTheOutside" ),
-                                         new File( "../dirOnTheOutside" ) );
-        Java7Support.createSymbolicLink( new File( srcDir, "symLinkToFileOnTheOutside" ),
-                                         new File( "../onTheOutside.txt" ) );
-        Java7Support.createSymbolicLink( new File( srcDir, "symR" ), new File( "fileR.txt" ) );
-        Java7Support.createSymbolicLink( new File( srcDir, "symW" ), new File( "fileW.txt" ) );
-        Java7Support.createSymbolicLink( new File( srcDir, "symX" ), new File( "fileX.txt" ) );
+        FileUtils.createSymbolicLink( new File( srcDir, "symDir" ), new File( "targetDir" ) );
+        FileUtils.createSymbolicLink( new File( srcDir, "symLinkToDirOnTheOutside" ), new File( "../dirOnTheOutside" ) );
+        FileUtils.createSymbolicLink( new File( srcDir, "symLinkToFileOnTheOutside" ), new File( "../onTheOutside.txt" ) );
+        FileUtils.createSymbolicLink( new File( srcDir, "symR" ), new File( "fileR.txt" ) );
+        FileUtils.createSymbolicLink( new File( srcDir, "symW" ), new File( "fileW.txt" ) );
+        FileUtils.createSymbolicLink( new File( srcDir, "symX" ), new File( "fileX.txt" ) );
         return srcDir;
     }
 }


### PR DESCRIPTION
I believe that Java 7 has been a minimum requirement for almost a year so here's some overdue cleanup:

- Call `java.nio.file.Files` utility methods directly rather than via reflection
- Move `createSymbolicLink()` utility to `FileUtils`
- Deprecate `Java7Support` and call `java.nio.file.Files` methods directly

MSHARED-860