### PR TITLE
[MSHARED-681] createSymbolicLink() overwrites existing different symlinks

### DIFF
--- a/src/main/java/org/apache/maven/shared/utils/io/FileUtils.java
+++ b/src/main/java/org/apache/maven/shared/utils/io/FileUtils.java
@@ -42,6 +42,7 @@ import java.net.URL;
 import java.nio.channels.FileChannel;
 import java.nio.charset.Charset;
 import java.nio.file.Files;
+import java.nio.file.Path;
 import java.security.SecureRandom;
 import java.text.DecimalFormat;
 import java.util.ArrayList;
@@ -2004,10 +2005,18 @@ public class FileUtils
     @Nonnull public static File createSymbolicLink( @Nonnull File symlink,  @Nonnull File target )
             throws IOException
     {
-        if ( !Files.exists( symlink.toPath() ) )
+        final Path symlinkPath = symlink.toPath();
+
+        if ( Files.exists( symlinkPath ) )
         {
-            return Files.createSymbolicLink( symlink.toPath(), target.toPath() ).toFile();
+            if ( target.equals( Files.readSymbolicLink( symlinkPath ).toFile() ) )
+            {
+                return symlink;
+            }
+
+            Files.delete( symlinkPath );
         }
-        return symlink;
+
+        return Files.createSymbolicLink( symlinkPath, target.toPath() ).toFile();
     }
 }

--- a/src/test/java/org/apache/maven/shared/utils/io/FileUtilsTest.java
+++ b/src/test/java/org/apache/maven/shared/utils/io/FileUtilsTest.java
@@ -1429,7 +1429,7 @@ public class FileUtilsTest
         throws IOException
     {
         // This testcase will pass when running under java7 or higher
-        assumeThat( Os.isFamily(Os.FAMILY_WINDOWS), is(false) );
+        assumeFalse( Os.isFamily( Os.FAMILY_WINDOWS ) );
 
         File file = new File( "src/test/resources/symlinks/src/symDir" );
         assertTrue(FileUtils.isSymbolicLink(file  ));
@@ -1466,7 +1466,8 @@ public class FileUtilsTest
     public void createAndReadSymlink()
         throws Exception
     {
-        assumeThat( System.getProperty( "os.name" ), not( startsWith( "Windows" ) ) );
+        assumeFalse( Os.isFamily( Os.FAMILY_WINDOWS ) );
+
         File file = new File( "target/fzz" );
         FileUtils.createSymbolicLink(  file, new File("../target") );
 
@@ -1479,7 +1480,7 @@ public class FileUtilsTest
     public void createSymbolicLinkWithDifferentTargetOverwritesSymlink()
             throws Exception
     {
-        assumeThat( System.getProperty( "os.name" ), not( startsWith( "Windows" ) ) );
+        assumeFalse( Os.isFamily( Os.FAMILY_WINDOWS ) );
 
         // Arrange
 

--- a/src/test/java/org/apache/maven/shared/utils/io/FileUtilsTest.java
+++ b/src/test/java/org/apache/maven/shared/utils/io/FileUtilsTest.java
@@ -1475,6 +1475,30 @@ public class FileUtilsTest
         Files.delete( file.toPath() );
     }
 
+    @Test
+    public void createSymbolicLinkWithDifferentTargetOverwritesSymlink()
+            throws Exception
+    {
+        assumeThat( System.getProperty( "os.name" ), not( startsWith( "Windows" ) ) );
+
+        // Arrange
+
+        final File symlink1 = new File( tempFolder.getRoot(), "symlink" );
+
+        FileUtils.createSymbolicLink( symlink1, testFile1 );
+
+        // Act
+
+        final File symlink2 = FileUtils.createSymbolicLink( symlink1, testFile2 );
+
+        // Assert
+
+        assertThat(
+            Files.readSymbolicLink( symlink2.toPath() ).toFile(),
+            CoreMatchers.equalTo( testFile2 )
+        );
+    }
+
     //// constants for testing
 
     private static final String[] MINIMUM_DEFAULT_EXCLUDES = {


### PR DESCRIPTION
Inspired by @mkarg's https://github.com/apache/maven-shared/pull/12/files but:

- Reimplemented in `FileUtils.createSymbolicLink()` since the utility method was moved from `Java7Support`.
- Read the existing symlink and only delete if it's incorrectly targeted
- Added a test confirming that symlinks are correctly overwritten
