### PR TITLE
[MSHARED-297] Unconditionally single quote executable and arguments

### DIFF
--- a/src/main/java/org/apache/maven/shared/utils/cli/shell/BourneShell.java
+++ b/src/main/java/org/apache/maven/shared/utils/cli/shell/BourneShell.java
@@ -34,7 +34,7 @@ public class BourneShell
     private static final char DOUBLE_QUOTATION = '"';
 
     private static final char[] BASH_QUOTING_TRIGGER_CHARS =
-        { ' ', '$', ';', '&', '|', '<', '>', '*', '?', '(', ')', '[', ']', '{', '}', '`' };
+        { ' ', '$', ';', '&', '|', '<', '>', '*', '?', '(', ')', '[', ']', '{', '}', '`', '#' };
 
     /**
      * Create instance of BourneShell.

--- a/src/main/java/org/apache/maven/shared/utils/cli/shell/BourneShell.java
+++ b/src/main/java/org/apache/maven/shared/utils/cli/shell/BourneShell.java
@@ -105,13 +105,8 @@ public class BourneShell
         }
 
         String dir = getWorkingDirectoryAsString();
-        StringBuilder sb = new StringBuilder();
-        sb.append( "cd " );
 
-        sb.append( quoteOneItem( dir, false ) );
-        sb.append( " && " );
-
-        return sb.toString();
+        return "cd " + quoteOneItem( dir, false ) + " && ";
     }
 
     /**
@@ -138,10 +133,6 @@ public class BourneShell
             return null;
         }
 
-        StringBuilder sb = new StringBuilder();
-        sb.append( "'" );
-        sb.append( path.replace( "'", "'\"'\"'" ) );
-        sb.append( "'" );
-        return sb.toString();
+        return "'" + path.replace( "'", "'\"'\"'" ) + "'";
     }
 }

--- a/src/main/java/org/apache/maven/shared/utils/cli/shell/Shell.java
+++ b/src/main/java/org/apache/maven/shared/utils/cli/shell/Shell.java
@@ -104,13 +104,13 @@ public class Shell
      */
     String[] getShellArgs()
     {
-        if ( ( shellArgs == null ) || shellArgs.isEmpty() )
+        if ( shellArgs.isEmpty() )
         {
             return null;
         }
         else
         {
-            return shellArgs.toArray( new String[shellArgs.size()] );
+            return shellArgs.toArray( new String[0] );
         }
     }
 
@@ -146,7 +146,7 @@ public class Shell
      */
     List<String> getRawCommandLine( String executableParameter, String... argumentsParameter )
     {
-        List<String> commandLine = new ArrayList<String>();
+        List<String> commandLine = new ArrayList<>();
         StringBuilder sb = new StringBuilder();
 
         if ( executableParameter != null )
@@ -280,7 +280,7 @@ public class Shell
     public List<String> getShellCommandLine( String... arguments )
     {
 
-        List<String> commandLine = new ArrayList<String>();
+        List<String> commandLine = new ArrayList<>();
 
         if ( getShellCommand() != null )
         {

--- a/src/main/java/org/apache/maven/shared/utils/cli/shell/Shell.java
+++ b/src/main/java/org/apache/maven/shared/utils/cli/shell/Shell.java
@@ -49,6 +49,8 @@ public class Shell
 
     private boolean quotedArgumentsEnabled = true;
 
+    private boolean unconditionalQuoting = false;
+
     private String executable;
 
     private String workingDir;
@@ -112,6 +114,19 @@ public class Shell
         }
     }
 
+    protected String quoteOneItem( String inputString, boolean isExecutable )
+    {
+        char[] escapeChars = getEscapeChars( isSingleQuotedExecutableEscaped(), isDoubleQuotedExecutableEscaped() );
+        return StringUtils.quoteAndEscape(
+                inputString,
+                isExecutable ? getExecutableQuoteDelimiter() : getArgumentQuoteDelimiter(),
+                escapeChars,
+                getQuotingTriggerChars(),
+                '\\',
+                unconditionalQuoting
+        );
+    }
+
     /**
      * Get the command line for the provided executable and arguments in this shell
      *
@@ -144,15 +159,11 @@ public class Shell
 
             if ( isQuotedExecutableEnabled() )
             {
-                char[] escapeChars =
-                    getEscapeChars( isSingleQuotedExecutableEscaped(), isDoubleQuotedExecutableEscaped() );
-
-                sb.append( StringUtils.quoteAndEscape( getExecutable(), getExecutableQuoteDelimiter(), escapeChars,
-                                                       getQuotingTriggerChars(), '\\', false ) );
+                sb.append( quoteOneItem( executableParameter, true ) );
             }
             else
             {
-                sb.append( getExecutable() );
+                sb.append( executableParameter );
             }
         }
         for ( String argument : argumentsParameter )
@@ -164,10 +175,7 @@ public class Shell
 
             if ( isQuotedArgumentsEnabled() )
             {
-                char[] escapeChars = getEscapeChars( isSingleQuotedArgumentEscaped(), isDoubleQuotedArgumentEscaped() );
-
-                sb.append( StringUtils.quoteAndEscape( argument, getArgumentQuoteDelimiter(), escapeChars,
-                                                       getQuotingTriggerChars(), '\\', false ) );
+                sb.append( quoteOneItem( argument, false ) );
             }
             else
             {
@@ -284,7 +292,7 @@ public class Shell
             commandLine.addAll( getShellArgsList() );
         }
 
-        commandLine.addAll( getCommandLine( getExecutable(), arguments ) );
+        commandLine.addAll( getCommandLine( executable, arguments ) );
 
         return commandLine;
 
@@ -398,4 +406,13 @@ public class Shell
         this.singleQuotedExecutableEscaped = singleQuotedExecutableEscaped;
     }
 
+    public boolean isUnconditionalQuoting()
+    {
+        return unconditionalQuoting;
+    }
+
+    public void setUnconditionalQuoting( boolean unconditionalQuoting )
+    {
+        this.unconditionalQuoting = unconditionalQuoting;
+    }
 }

--- a/src/test/java/org/apache/maven/shared/utils/cli/CommandLineUtilsTest.java
+++ b/src/test/java/org/apache/maven/shared/utils/cli/CommandLineUtilsTest.java
@@ -148,8 +148,8 @@ public class CommandLineUtilsTest
     public void givenAnEscapedSingleQuoteMarkInArgument_whenTranslatingToCmdLineArgs_thenTheQuotationMarkRemainsEscaped()
         throws Exception
     {
-        final String command = "echo \"let\\\'s go\"";
-        final String[] expected = new String[] { "echo", "let\\\'s go" };
+        final String command = "echo \"let\\'s go\"";
+        final String[] expected = new String[] { "echo", "let\\'s go"};
         assertCmdLineArgs( expected, command );
     }
 
@@ -168,5 +168,4 @@ public class CommandLineUtilsTest
         assertEquals( expected.length, actual.length );
         assertEquals( Arrays.asList( expected ), Arrays.asList( actual ) );
     }
-
 }

--- a/src/test/java/org/apache/maven/shared/utils/cli/shell/BourneShellTest.java
+++ b/src/test/java/org/apache/maven/shared/utils/cli/shell/BourneShellTest.java
@@ -42,7 +42,7 @@ public class BourneShellTest
         sh.setWorkingDirectory( "/usr/local/bin" );
         sh.setExecutable( "chmod" );
 
-        String executable = StringUtils.join( sh.getShellCommandLine( new String[]{} ).iterator(), " " );
+        String executable = StringUtils.join( sh.getShellCommandLine().iterator(), " " );
 
         assertEquals( "/bin/sh -c cd '/usr/local/bin' && 'chmod'", executable );
     }
@@ -54,7 +54,7 @@ public class BourneShellTest
         sh.setWorkingDirectory( "/usr/local/'something else'" );
         sh.setExecutable( "chmod" );
 
-        String executable = StringUtils.join( sh.getShellCommandLine( new String[]{} ).iterator(), " " );
+        String executable = StringUtils.join( sh.getShellCommandLine().iterator(), " " );
 
         assertEquals( "/bin/sh -c cd '/usr/local/'\"'\"'something else'\"'\"'' && 'chmod'", executable );
     }
@@ -66,7 +66,7 @@ public class BourneShellTest
         sh.setWorkingDirectory( "\\usr\\local\\'something else'" );
         sh.setExecutable( "chmod" );
 
-        String executable = StringUtils.join( sh.getShellCommandLine( new String[]{} ).iterator(), " " );
+        String executable = StringUtils.join( sh.getShellCommandLine().iterator(), " " );
 
         assertEquals( "/bin/sh -c cd '\\usr\\local\\'\"'\"'something else'\"'\"'' && 'chmod'", executable );
     }
@@ -78,9 +78,7 @@ public class BourneShellTest
         sh.setWorkingDirectory( "/usr/bin" );
         sh.setExecutable( "chmod" );
 
-        final String[] args = { "\"some arg with spaces\"" };
-
-        List<String> shellCommandLine = sh.getShellCommandLine( args );
+        List<String> shellCommandLine = sh.getShellCommandLine("\"some arg with spaces\"");
 
         String cli = StringUtils.join( shellCommandLine.iterator(), " " );
         System.out.println( cli );
@@ -94,9 +92,7 @@ public class BourneShellTest
         sh.setWorkingDirectory( "/usr/bin" );
         sh.setExecutable( "chmod" );
 
-        String[] args = { "some arg with spaces" };
-
-        List<String> shellCommandLine = sh.getShellCommandLine( args );
+        List<String> shellCommandLine = sh.getShellCommandLine("some arg with spaces");
 
         String cli = StringUtils.join( shellCommandLine.iterator(), " " );
         System.out.println( cli );
@@ -110,9 +106,7 @@ public class BourneShellTest
         sh.setWorkingDirectory( "/usr/bin" );
         sh.setExecutable( "chmod" );
 
-        String[] args = { "arg'withquote" };
-
-        List<String> shellCommandLine = sh.getShellCommandLine( args );
+        List<String> shellCommandLine = sh.getShellCommandLine("arg'withquote");
 
         assertEquals("cd '/usr/bin' && 'chmod' 'arg'\"'\"'withquote'", shellCommandLine.get(shellCommandLine.size() - 1));
     }
@@ -127,9 +121,7 @@ public class BourneShellTest
         sh.setWorkingDirectory( "/usr/bin" );
         sh.setExecutable( "chmod" );
 
-        String[] args = { ";some&argwithunix$chars" };
-
-        List<String> shellCommandLine = sh.getShellCommandLine( args );
+        List<String> shellCommandLine = sh.getShellCommandLine(";some&argwithunix$chars");
 
         String cli = StringUtils.join( shellCommandLine.iterator(), " " );
         System.out.println( cli );

--- a/src/test/java/org/apache/maven/shared/utils/cli/shell/BourneShellTest.java
+++ b/src/test/java/org/apache/maven/shared/utils/cli/shell/BourneShellTest.java
@@ -44,7 +44,7 @@ public class BourneShellTest
 
         String executable = StringUtils.join( sh.getShellCommandLine( new String[]{} ).iterator(), " " );
 
-        assertEquals( "/bin/sh -c cd /usr/local/bin && chmod", executable );
+        assertEquals( "/bin/sh -c cd '/usr/local/bin' && 'chmod'", executable );
     }
 
     public void testQuoteWorkingDirectoryAndExecutable_WDPathWithSingleQuotes()
@@ -56,7 +56,7 @@ public class BourneShellTest
 
         String executable = StringUtils.join( sh.getShellCommandLine( new String[]{} ).iterator(), " " );
 
-        assertEquals( "/bin/sh -c cd \"/usr/local/\'something else\'\" && chmod", executable );
+        assertEquals( "/bin/sh -c cd '/usr/local/'\"'\"'something else'\"'\"'' && 'chmod'", executable );
     }
 
     public void testQuoteWorkingDirectoryAndExecutable_WDPathWithSingleQuotes_BackslashFileSep()
@@ -68,7 +68,7 @@ public class BourneShellTest
 
         String executable = StringUtils.join( sh.getShellCommandLine( new String[]{} ).iterator(), " " );
 
-        assertEquals( "/bin/sh -c cd \"\\usr\\local\\\'something else\'\" && chmod", executable );
+        assertEquals( "/bin/sh -c cd '\\usr\\local\\'\"'\"'something else'\"'\"'' && 'chmod'", executable );
     }
 
     public void testPreserveSingleQuotesOnArgument()
@@ -84,7 +84,7 @@ public class BourneShellTest
 
         String cli = StringUtils.join( shellCommandLine.iterator(), " " );
         System.out.println( cli );
-        assertTrue( cli.endsWith( args[0] ) );
+        assertTrue( cli.endsWith( "'\"some arg with spaces\"'" ) );
     }
 
     public void testAddSingleQuotesOnArgumentWithSpaces()
@@ -100,7 +100,21 @@ public class BourneShellTest
 
         String cli = StringUtils.join( shellCommandLine.iterator(), " " );
         System.out.println( cli );
-        assertTrue( cli.endsWith( "\"" + args[0] + "\"" ) );
+        assertTrue( cli.endsWith("'some arg with spaces'"));
+    }
+
+    public void testAddArgumentWithSingleQuote()
+    {
+        Shell sh = newShell();
+
+        sh.setWorkingDirectory( "/usr/bin" );
+        sh.setExecutable( "chmod" );
+
+        String[] args = { "arg'withquote" };
+
+        List<String> shellCommandLine = sh.getShellCommandLine( args );
+
+        assertEquals("cd '/usr/bin' && 'chmod' 'arg'\"'\"'withquote'", shellCommandLine.get(shellCommandLine.size() - 1));
     }
 
     public void testArgumentsWithSemicolon()
@@ -119,7 +133,7 @@ public class BourneShellTest
 
         String cli = StringUtils.join( shellCommandLine.iterator(), " " );
         System.out.println( cli );
-        assertTrue( cli.endsWith( "\"" + args[0] + "\"" ) );
+        assertTrue( cli.endsWith( "';some&argwithunix$chars'" ) );
 
         Commandline commandline = new Commandline( newShell() );
         commandline.setExecutable( "chmod" );
@@ -132,7 +146,7 @@ public class BourneShellTest
 
         assertEquals( "/bin/sh", lines.get( 0 ) );
         assertEquals( "-c", lines.get( 1 ) );
-        assertEquals( "chmod --password \";password\"", lines.get( 2 ) );
+        assertEquals( "'chmod' '--password' ';password'", lines.get( 2 ) );
 
         commandline = new Commandline( newShell() );
         commandline.setExecutable( "chmod" );
@@ -144,7 +158,7 @@ public class BourneShellTest
 
         assertEquals( "/bin/sh", lines.get( 0) );
         assertEquals( "-c", lines.get( 1 ) );
-        assertEquals( "chmod --password \";password\"", lines.get( 2 ) );
+        assertEquals( "'chmod' '--password' ';password'", lines.get( 2 ) );
 
         commandline = new Commandline( new CmdShell() );
         commandline.getShell().setQuotedArgumentsEnabled( true );
@@ -193,7 +207,7 @@ public class BourneShellTest
 
         assertEquals( "/bin/sh", lines.get( 0 ) );
         assertEquals( "-c", lines.get( 1 ) );
-        assertEquals( "chmod \" \" \"|\" \"&&\" \"||\" \";\" \";;\" \"&\" \"()\" \"<\" \"<<\" \">\" \">>\" \"*\" \"?\" \"[\" \"]\" \"{\" \"}\" \"`\" \"#\"",
+        assertEquals( "'chmod' ' ' '|' '&&' '||' ';' ';;' '&' '()' '<' '<<' '>' '>>' '*' '?' '[' ']' '{' '}' '`' '#'",
                       lines.get( 2 ) );
     }
 

--- a/src/test/java/org/apache/maven/shared/utils/cli/shell/BourneShellTest.java
+++ b/src/test/java/org/apache/maven/shared/utils/cli/shell/BourneShellTest.java
@@ -186,13 +186,14 @@ public class BourneShellTest
         commandline.createArg().setValue( "{" );
         commandline.createArg().setValue( "}" );
         commandline.createArg().setValue( "`" );
+        commandline.createArg().setValue( "#" );
 
         List<String> lines = commandline.getShell().getShellCommandLine( commandline.getArguments() );
         System.out.println( lines  );
 
         assertEquals( "/bin/sh", lines.get( 0 ) );
         assertEquals( "-c", lines.get( 1 ) );
-        assertEquals( "chmod \" \" \"|\" \"&&\" \"||\" \";\" \";;\" \"&\" \"()\" \"<\" \"<<\" \">\" \">>\" \"*\" \"?\" \"[\" \"]\" \"{\" \"}\" \"`\"",
+        assertEquals( "chmod \" \" \"|\" \"&&\" \"||\" \";\" \";;\" \"&\" \"()\" \"<\" \"<<\" \">\" \">>\" \"*\" \"?\" \"[\" \"]\" \"{\" \"}\" \"`\" \"#\"",
                       lines.get( 2 ) );
     }
 


### PR DESCRIPTION
- Escape arguments containing `#`, with unit test
  - Closes [MSHARED-431](https://issues.apache.org/jira/browse/MSHARED-431)
- Partial port of https://github.com/sonatype/plexus-utils/commit/b38a1b3a4352303e4312b2bb601a0d7ec6e28f41
  - BourneShell unconditionally single quotes the executable and arguments
  - ~~Shell usage is only desirable when generating code for remote execution~~ omitted because shell usage is also required for running built-in commands such as `echo` as used in the tests.
  - Closes [MSHARED-297](https://issues.apache.org/jira/browse/MSHARED-297)