### PR TITLE
docs: correct API docs for clean and trim

### DIFF
--- a/src/main/java/org/apache/maven/shared/utils/StringUtils.java
+++ b/src/main/java/org/apache/maven/shared/utils/StringUtils.java
@@ -69,7 +69,7 @@ public class StringUtils
     //--------------------------------------------------------------------------
 
     /**
-     * <p>Removes control characters, including whitespace, from both
+     * <p>Removes C0 control characters, including ASCII whitespace, from both
      * ends of this String, handling <code>null</code> by returning
      * an empty String.</p>
      *
@@ -83,7 +83,7 @@ public class StringUtils
     }
 
     /**
-     * <p>Removes control characters, including whitespace, from both
+     * <p>Removes C0 control characters, including ASCII whitespace, from both
      * ends of this String, handling <code>null</code> by returning
      * <code>null</code>.</p>
      *
@@ -530,10 +530,10 @@ public class StringUtils
      * <p>Splits the provided text into a array, based on a given separator.</p>
      * <p/>
      * <p>The separator is not included in the returned String array. The
-     * maximum number of splits to perfom can be controlled. A <code>null</code>
-     * separator will cause parsing to be on whitespace.</p>
+     * maximum number of splits to perform can be controlled. A <code>null</code>
+     * separator causes splitting on whitespace.</p>
      * <p/>
-     * <p>This is useful for quickly splitting a String directly into
+     * <p>This is useful for quickly splitting a String  into
      * an array of tokens, instead of an enumeration of tokens (as
      * <code>StringTokenizer</code> does).</p>
      *

--- a/src/main/java/org/apache/maven/shared/utils/StringUtils.java
+++ b/src/main/java/org/apache/maven/shared/utils/StringUtils.java
@@ -1688,7 +1688,7 @@ public class StringUtils
      *
      * @param str the String to check
      * @param sub the substring to count
-     * @return the number of occurances, 0 if the String is <code>null</code>
+     * @return the number of occurrences, 0 if the String is <code>null</code>
      * @throws NullPointerException if sub is <code>null</code>
      */
     public static int countMatches( @Nullable String str, @Nonnull String sub )
@@ -1715,7 +1715,7 @@ public class StringUtils
     //--------------------------------------------------------------------------
 
     /**
-     * <p>Checks if the String contains only unicode letters.</p>
+     * <p>Checks if the String contains only Unicode letters.</p>
      * <p/>
      * <p><code>null</code> will return <code>false</code>.
      * An empty String will return <code>true</code>.</p>
@@ -1767,7 +1767,7 @@ public class StringUtils
     }
 
     /**
-     * <p>Checks if the String contains only unicode letters and
+     * <p>Checks if the String contains only Unicode letters and
      * space (<code>' '</code>).</p>
      * <p/>
      * <p><code>null</code> will return <code>false</code>. An
@@ -1795,7 +1795,7 @@ public class StringUtils
     }
 
     /**
-     * <p>Checks if the String contains only unicode letters or digits.</p>
+     * <p>Checks if the String contains only Unicode letters or digits.</p>
      * <p/>
      * <p><code>null</code> will return <code>false</code>. An empty
      * String will return <code>true</code>.</p>
@@ -1822,7 +1822,7 @@ public class StringUtils
     }
 
     /**
-     * <p>Checks if the String contains only unicode letters, digits
+     * <p>Checks if the String contains only Unicode letters, digits
      * or space (<code>' '</code>).</p>
      * <p/>
      * <p><code>null</code> will return <code>false</code>. An empty
@@ -1850,7 +1850,7 @@ public class StringUtils
     }
 
     /**
-     * <p>Checks if the String contains only unicode digits.</p>
+     * <p>Checks if the String contains only Unicode digits.</p>
      * <p/>
      * <p><code>null</code> will return <code>false</code>.
      * An empty String will return <code>true</code>.</p>


### PR DESCRIPTION
@michael-o Contrary to previous documentation these methods do not remove all whitespace and control characters, only ASCII whitespace and control characters. 