### PR TITLE
[MSHARED-983] Drop plexus container default

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -27,7 +27,7 @@
   </parent>
 
   <artifactId>maven-shared-utils</artifactId>
-  <version>3.3.5-SNAPSHOT</version>
+  <version>4.0.0-SNAPSHOT</version>
 
   <name>Apache Maven Shared Utils</name>
   <description>Shared utilities for use by Maven core and plugins</description>

--- a/pom.xml
+++ b/pom.xml
@@ -68,11 +68,24 @@
 
   <dependencies>
     <dependency>
+      <groupId>org.slf4j</groupId>
+      <artifactId>slf4j-api</artifactId>
+      <version>1.7.25</version>
+    </dependency>
+
+    <dependency>
       <groupId>org.fusesource.jansi</groupId>
       <artifactId>jansi</artifactId>
       <version>2.2.0</version>
       <optional>true</optional>
     </dependency>
+
+    <dependency>
+      <groupId>commons-io</groupId>
+      <artifactId>commons-io</artifactId>
+      <version>2.6</version>
+    </dependency>
+
     <dependency>
       <groupId>junit</groupId>
       <artifactId>junit</artifactId>
@@ -84,11 +97,6 @@
       <artifactId>hamcrest-core</artifactId>
       <version>2.2</version>
       <scope>test</scope>
-    </dependency>
-    <dependency>
-      <groupId>commons-io</groupId>
-      <artifactId>commons-io</artifactId>
-      <version>2.6</version>
     </dependency>
     <dependency>
       <groupId>org.apache.commons</groupId>
@@ -110,12 +118,6 @@
       <artifactId>maven-core</artifactId>
       <version>${mavenVersion}</version>
       <scope>test</scope>
-    </dependency>
-    <dependency>
-      <groupId>org.codehaus.plexus</groupId>
-      <artifactId>plexus-container-default</artifactId>
-      <version>2.1.0</version>
-      <scope>provided</scope>
     </dependency>
     <dependency>
       <groupId>org.codehaus.plexus</groupId>

--- a/src/main/java/org/apache/maven/shared/utils/cli/javatool/AbstractJavaTool.java
+++ b/src/main/java/org/apache/maven/shared/utils/cli/javatool/AbstractJavaTool.java
@@ -25,7 +25,8 @@ import org.apache.maven.shared.utils.cli.CommandLineException;
 import org.apache.maven.shared.utils.cli.CommandLineUtils;
 import org.apache.maven.shared.utils.cli.Commandline;
 import org.apache.maven.shared.utils.cli.StreamConsumer;
-import org.codehaus.plexus.logging.AbstractLogEnabled;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 import java.io.File;
 import java.io.InputStream;
@@ -41,9 +42,9 @@ import java.util.Map;
  * @param <Request> Tool-specific request type
  */
 public abstract class AbstractJavaTool<Request extends JavaToolRequest>
-    extends AbstractLogEnabled
     implements JavaTool<Request>
 {
+    private final Logger logger = LoggerFactory.getLogger( getClass() );
 
     /**
      * The java tool name to find out in the jdk.
@@ -78,6 +79,11 @@ public abstract class AbstractJavaTool<Request extends JavaToolRequest>
      */
     protected abstract Commandline createCommandLine( Request request, String javaToolFileLocation )
         throws JavaToolException;
+
+    protected Logger getLogger()
+    {
+        return logger;
+    }
 
     /**
      * {@inheritDoc}


### PR DESCRIPTION
https://issues.apache.org/jira/browse/MSHARED-983

The complete container was only here to make use of AbstractLogEnabled
ancient class, that uses ancient logging.

Changes:
* Drop p-c-d
* Reorder deps by scope, test last.