### PR TITLE
(doc) Throw more descriptive NPEx

### DIFF
--- a/src/main/java/org/apache/maven/shared/utils/io/DirectoryScanner.java
+++ b/src/main/java/org/apache/maven/shared/utils/io/DirectoryScanner.java
@@ -321,6 +321,10 @@ public class DirectoryScanner
             this.includes = new String[includes.length];
             for ( int i = 0; i < includes.length; i++ )
             {
+                if ( includes[i] == null )
+                {
+                    throw new NullPointerException( messageForNullListElement( "includes" ) );
+                }
                 String pattern;
                 pattern = includes[i].trim().replace( '/', File.separatorChar ).replace( '\\', File.separatorChar );
                 if ( pattern.endsWith( File.separator ) )
@@ -353,6 +357,10 @@ public class DirectoryScanner
             this.excludes = new String[excludes.length];
             for ( int i = 0; i < excludes.length; i++ )
             {
+                if ( excludes[i] == null )
+                {
+                    throw new NullPointerException( messageForNullListElement( "excludes" ) );
+                }
                 String pattern;
                 pattern = excludes[i].trim().replace( '/', File.separatorChar ).replace( '\\', File.separatorChar );
                 if ( pattern.endsWith( File.separator ) )
@@ -362,6 +370,11 @@ public class DirectoryScanner
                 this.excludes[i] = pattern;
             }
         }
+    }
+
+    private static String messageForNullListElement( String listName )
+    {
+        return "If a non-null " + listName + " list is given, all elements must be non-null";
     }
 
     /**

--- a/src/test/java/org/apache/maven/shared/utils/io/DirectoryScannerTest.java
+++ b/src/test/java/org/apache/maven/shared/utils/io/DirectoryScannerTest.java
@@ -25,6 +25,7 @@ import org.junit.Assert;
 import org.junit.Ignore;
 import org.junit.Rule;
 import org.junit.Test;
+import org.junit.rules.ExpectedException;
 import org.junit.rules.TemporaryFolder;
 
 import java.io.File;
@@ -120,6 +121,40 @@ public class DirectoryScannerTest
         fitScanTest( true, false, true,
                 /* includes        */ new String[]{ "**/*.dat", "*.somethingelse" },
                 /* excludes        */ null,
+                /* expInclFiles    */ new String[]{ "file3.dat", "folder1/file5.dat" },
+                /* expInclDirs     */ NONE,
+                /* expNotInclFiles */ new String[]{ "file1.txt", "file2.txt", "folder1/file4.txt" },
+                /* expNotInclDirs  */ new String[]{ "", "folder1" },
+                /* expExclFiles    */ NONE,
+                /* expExclDirs     */ NONE );
+    }
+
+    @Rule
+    public ExpectedException xcludesNPExRule = ExpectedException.none();
+
+    @Test
+    public void testIncludesWithNull()
+        throws Exception
+    {
+        testXcludesWithNull( new String[]{ null }, null );
+    }
+
+    @Test
+    public void testExcludesWithNull()
+        throws Exception
+    {
+        testXcludesWithNull( null, new String[]{ null } );
+    }
+
+    private void testXcludesWithNull( String[] includes, String[] excludes )
+        throws Exception
+    {
+        createTestData();
+        xcludesNPExRule.expect( NullPointerException.class );
+
+        fitScanTest( true, true, true,
+                /* includes        */ includes,
+                /* excludes        */ excludes,
                 /* expInclFiles    */ new String[]{ "file3.dat", "folder1/file5.dat" },
                 /* expInclDirs     */ NONE,
                 /* expNotInclFiles */ new String[]{ "file1.txt", "file2.txt", "folder1/file4.txt" },

--- a/src/test/java/org/apache/maven/shared/utils/io/DirectoryScannerTest.java
+++ b/src/test/java/org/apache/maven/shared/utils/io/DirectoryScannerTest.java
@@ -136,21 +136,22 @@ public class DirectoryScannerTest
     public void testIncludesWithNull()
         throws Exception
     {
-        testXcludesWithNull( new String[]{ null }, null );
+        testXcludesWithNull( new String[]{ null }, null, "includes" );
     }
 
     @Test
     public void testExcludesWithNull()
         throws Exception
     {
-        testXcludesWithNull( null, new String[]{ null } );
+        testXcludesWithNull( null, new String[]{ null }, "excludes" );
     }
 
-    private void testXcludesWithNull( String[] includes, String[] excludes )
+    private void testXcludesWithNull( String[] includes, String[] excludes, String listName )
         throws Exception
     {
         createTestData();
         xcludesNPExRule.expect( NullPointerException.class );
+        xcludesNPExRule.expectMessage( "If a non-null " + listName + " list is given, all elements must be non-null" );
 
         fitScanTest( true, true, true,
                 /* includes        */ includes,


### PR DESCRIPTION
As suggested in [MJAR-286](https://issues.apache.org/jira/browse/MJAR-286):
> If this is a misconfigured pom, it should at least give a proper error message.

Thus replacing JVM-thrown NPEx with the one with message.