### PR TITLE
[MSHARED-1122] FileUtils: avoid getCanonicalPath()

### DIFF
--- a/src/main/java/org/apache/maven/shared/utils/io/FileUtils.java
+++ b/src/main/java/org/apache/maven/shared/utils/io/FileUtils.java
@@ -815,7 +815,7 @@ public class FileUtils
         }
 
         //check source != destination, see PLXUTILS-10
-        if ( source.getCanonicalPath().equals( destination.getCanonicalPath() ) )
+        if ( destination.exists() && Files.isSameFile( source.toPath(), destination.toPath() ) )
         {
             //if they are equal, we can exit the method without doing any work
             return;


### PR DESCRIPTION
Use java.nio.Files.isSameFile() to compare path. Since JDK 12
getCanonicalPath() is not cached anymore and very slow on windows.