### PR TITLE
[MSHARED-1172] Deprecate redundant isEmptyString method

### DIFF
--- a/src/main/java/org/apache/maven/shared/utils/xml/Xpp3DomUtils.java
+++ b/src/main/java/org/apache/maven/shared/utils/xml/Xpp3DomUtils.java
@@ -148,8 +148,8 @@ public class Xpp3DomUtils
     }
 
     /**
-     * @deprecated use <code>String.isBlank(str)</code> (Java 11+) 
-     *             or <code>str == null || org.apache.commons.lang3.StringUtils.isBlank(str)</code>
+     * @deprecated use <code>str == null || String.isBlank(str)</code> (Java 11+) 
+     *             or <code>org.apache.commons.lang3.StringUtils.isBlank(str)</code>
      * @param str the string to be checked
      * @return <code>true</code> if the string is null, empty, or whitespace only; <code>false</code> otherwise
      */

--- a/src/main/java/org/apache/maven/shared/utils/xml/Xpp3DomUtils.java
+++ b/src/main/java/org/apache/maven/shared/utils/xml/Xpp3DomUtils.java
@@ -148,8 +148,8 @@ public class Xpp3DomUtils
     }
 
     /**
-     * @deprecated use <code>String.isBlank()</code> (Java 11+) 
-     *             or <code>org.apache.commons.lang3.StringUtils.isBlank()</code>
+     * @deprecated use <code>String.isBlank(str)</code> (Java 11+) 
+     *             or <code>str == null || org.apache.commons.lang3.StringUtils.isBlank(str)</code>
      * @param str the string to be checked
      * @return <code>true</code> if the string is null, empty, or whitespace only; <code>false</code> otherwise
      */

--- a/src/main/java/org/apache/maven/shared/utils/xml/Xpp3DomUtils.java
+++ b/src/main/java/org/apache/maven/shared/utils/xml/Xpp3DomUtils.java
@@ -148,15 +148,14 @@ public class Xpp3DomUtils
     }
 
     /**
-     * @param str The string to be checked.
-     * @return <code>true</code> in case string is empty <code>false</code> otherwise.
+     * @deprecated use <code>String.isBlank()</code> (Java 11+) or <code>org.apache.commons.lang3.StringUtils.isBlank()</code> 
+     * @param str the string to be checked
+     * @return <code>true</code> if the string is null, empty, or whitespace only; <code>false</code> otherwise
      */
+    @Deprecated
     public static boolean isEmpty( String str )
     {
         return str == null || str.trim().length() == 0;
     }
-
-
-
 
 }

--- a/src/main/java/org/apache/maven/shared/utils/xml/Xpp3DomUtils.java
+++ b/src/main/java/org/apache/maven/shared/utils/xml/Xpp3DomUtils.java
@@ -148,7 +148,8 @@ public class Xpp3DomUtils
     }
 
     /**
-     * @deprecated use <code>String.isBlank()</code> (Java 11+) or <code>org.apache.commons.lang3.StringUtils.isBlank()</code> 
+     * @deprecated use <code>String.isBlank()</code> (Java 11+) 
+     *             or <code>org.apache.commons.lang3.StringUtils.isBlank()</code>
      * @param str the string to be checked
      * @return <code>true</code> if the string is null, empty, or whitespace only; <code>false</code> otherwise
      */


### PR DESCRIPTION
deprecate a string utility method that doesn't belong in this package, wasn't correctly documented, isn't tested, and is duplicated in 72 other places

@slawekjaranowski