### PR TITLE
[MSHARED-953] don't trim

### DIFF
--- a/src/test/java/org/apache/maven/shared/utils/xml/Xpp3DomBuilderTest.java
+++ b/src/test/java/org/apache/maven/shared/utils/xml/Xpp3DomBuilderTest.java
@@ -74,7 +74,8 @@ public class Xpp3DomBuilderTest
     }
 
     
-    @Test
+    @SuppressWarnings("deprecation")
+	@Test
     public void trimming()
         throws Exception
     {
@@ -82,7 +83,7 @@ public class Xpp3DomBuilderTest
 
         Xpp3Dom dom = Xpp3DomBuilder.build( new StringReader( domString ), true );
 
-        assertEquals( "element1value", dom.getChild( "element1" ).getValue() );
+        assertEquals( " element1value\n ", dom.getChild( "element1" ).getValue() );
 
         assertEquals( "  preserve space  ", dom.getChild( "element6" ).getValue() );
 


### PR DESCRIPTION
The alternative fix, which might be less invasive, is to move the trimming into the endElement method. 