### PR TITLE
[MSHARED-1014] Make Commandline.addSystemEnvironment public and deprecated

### DIFF
--- a/src/main/java/org/apache/maven/shared/utils/cli/Commandline.java
+++ b/src/main/java/org/apache/maven/shared/utils/cli/Commandline.java
@@ -183,8 +183,13 @@ public class Commandline implements Cloneable {
 
     /**
      * Add system environment variables.
+     *
+     * @deprecated please use {@link #setShellEnvironmentInherited(boolean)}
      */
-    private void addSystemEnvironment() {
+    @Deprecated
+    public void addSystemEnvironment() {}
+
+    private void copySystemEnvironment() {
         Properties systemEnvVars = CommandLineUtils.getSystemEnvVars();
 
         for (Object o : systemEnvVars.keySet()) {
@@ -202,7 +207,7 @@ public class Commandline implements Cloneable {
      */
     public String[] getEnvironmentVariables() {
         if (isShellEnvironmentInherited()) {
-            addSystemEnvironment();
+            copySystemEnvironment();
         }
 
         List<String> environmentVars = new ArrayList<>();


### PR DESCRIPTION
MavenInvoker still use it.

 ... or run release train shared-utils -> maven-invoker -> m-release-p