### PR TITLE
fix hamcrest dependencies as best we can

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -87,15 +87,21 @@
     </dependency>
 
     <dependency>
-      <groupId>junit</groupId>
-      <artifactId>junit</artifactId>
-      <version>4.13.2</version>
+      <groupId>org.hamcrest</groupId>
+      <artifactId>hamcrest</artifactId>
+      <version>2.2</version>
       <scope>test</scope>
     </dependency>
     <dependency>
       <groupId>org.hamcrest</groupId>
       <artifactId>hamcrest-core</artifactId>
       <version>2.2</version>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
+      <groupId>junit</groupId>
+      <artifactId>junit</artifactId>
+      <version>4.13.2</version>
       <scope>test</scope>
     </dependency>
     <dependency>


### PR DESCRIPTION
see https://hamcrest.org/JavaHamcrest/distributables

This takes the build from two warnings to one, and provides the latest version of hamcrest. Getting rid of that last warning, might require some work in the dependency analyzer.