### PR TITLE
[MSHARED-1255] use dependencyManagement to set hamcrest-core version

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -66,6 +66,16 @@
     <mavenVersion>3.2.5</mavenVersion>
   </properties>
 
+  <dependencyManagement>
+    <dependencies>
+      <dependency>
+        <groupId>org.hamcrest</groupId>
+        <artifactId>hamcrest-core</artifactId>
+        <version>2.2</version>
+      </dependency>
+    </dependencies>
+  </dependencyManagement>
+
   <dependencies>
     <dependency>
       <groupId>org.slf4j</groupId>
@@ -89,12 +99,6 @@
     <dependency>
       <groupId>org.hamcrest</groupId>
       <artifactId>hamcrest</artifactId>
-      <version>2.2</version>
-      <scope>test</scope>
-    </dependency>
-    <dependency>
-      <groupId>org.hamcrest</groupId>
-      <artifactId>hamcrest-core</artifactId>
       <version>2.2</version>
       <scope>test</scope>
     </dependency>


### PR DESCRIPTION
Removes dependency warning but still selects the right version of hamcrest-core in transitive dependencies. See https://hamcrest.org/JavaHamcrest/distributables