### PR TITLE
[MSHARED-1269] Deprecate maven-shared-utils

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,6 +14,12 @@
  See the License for the specific language governing permissions and
  limitations under the License.
 -->
+Deprecation
+======================
+The [Apache Maven Shared Utils](https://maven.apache.org/shared/maven-shared-utils/) library has been deprecated in favor 
+of [Plexus Utils](https://github.com/codehaus.plexus/plexus-utils) and [Plexus XML](https://github.com/codehaus.plexus/plexus-xml).
+Please switch to using those libraries.
+
 Contributing to [Apache Maven Shared Utils](https://maven.apache.org/shared/maven-shared-utils/)
 ======================
 

--- a/src/main/java/org/apache/maven/shared/utils/Os.java
+++ b/src/main/java/org/apache/maven/shared/utils/Os.java
@@ -38,6 +38,7 @@ import java.util.Set;
  * @author Mark Struberg
  *
  */
+@Deprecated
 public class Os {
     /**
      * The OS Name.

--- a/src/main/java/org/apache/maven/shared/utils/PathTool.java
+++ b/src/main/java/org/apache/maven/shared/utils/PathTool.java
@@ -33,6 +33,7 @@ import java.util.StringTokenizer;
  * Some external fixes by Apache Committers have been applied later.
  * </p>
  */
+@Deprecated
 public class PathTool {
 
     /**

--- a/src/main/java/org/apache/maven/shared/utils/PropertyUtils.java
+++ b/src/main/java/org/apache/maven/shared/utils/PropertyUtils.java
@@ -31,6 +31,7 @@ import java.util.Properties;
 /**
  * Static utility methods for loading properties.
  */
+@Deprecated
 public class PropertyUtils {
 
     /**

--- a/src/main/java/org/apache/maven/shared/utils/ReaderFactory.java
+++ b/src/main/java/org/apache/maven/shared/utils/ReaderFactory.java
@@ -42,6 +42,7 @@ import org.apache.commons.io.input.XmlStreamReader;
  * @see <a href="https://docs.oracle.com/javase/8/docs/technotes/guides/intl/encoding.doc.html">Supported encodings</a>
  * @deprecated use JDK methods instead
  */
+@Deprecated
 public class ReaderFactory {
     /**
      * ISO Latin Alphabet #1, also known as ISO-LATIN-1.

--- a/src/main/java/org/apache/maven/shared/utils/StringUtils.java
+++ b/src/main/java/org/apache/maven/shared/utils/StringUtils.java
@@ -49,6 +49,7 @@ import java.util.StringTokenizer;
  * @author <a href="mailto:alex@purpletech.com">Alexander Day Chaffee</a>
  *
  */
+@Deprecated
 public class StringUtils {
     /**
      * <p><code>StringUtils</code> instances should NOT be constructed in

--- a/src/main/java/org/apache/maven/shared/utils/cli/AbstractStreamHandler.java
+++ b/src/main/java/org/apache/maven/shared/utils/cli/AbstractStreamHandler.java
@@ -21,6 +21,7 @@ package org.apache.maven.shared.utils.cli;
 /**
  * @author <a href="mailto:kristian.rosenvold@gmail.com">Kristian Rosenvold</a>
  */
+@Deprecated
 class AbstractStreamHandler extends Thread {
     private volatile boolean done;
 

--- a/src/main/java/org/apache/maven/shared/utils/cli/Arg.java
+++ b/src/main/java/org/apache/maven/shared/utils/cli/Arg.java
@@ -23,6 +23,7 @@ import java.io.File;
 /**
  *
  */
+@Deprecated
 public interface Arg {
     /**
      * @param value the value to be set

--- a/src/main/java/org/apache/maven/shared/utils/cli/CommandLineCallable.java
+++ b/src/main/java/org/apache/maven/shared/utils/cli/CommandLineCallable.java
@@ -25,6 +25,7 @@ import java.util.concurrent.Callable;
  *
  * @author Kristian Rosenvold
  */
+@Deprecated
 public interface CommandLineCallable extends Callable<Integer> {
     /**
      * {@inheritDoc}

--- a/src/main/java/org/apache/maven/shared/utils/cli/CommandLineException.java
+++ b/src/main/java/org/apache/maven/shared/utils/cli/CommandLineException.java
@@ -21,6 +21,7 @@ package org.apache.maven.shared.utils.cli;
 /**
  * @author <a href="mailto:trygvis@inamo.no">Trygve Laugst&oslash;l</a>
  */
+@Deprecated
 public class CommandLineException extends Exception {
     /**
      *

--- a/src/main/java/org/apache/maven/shared/utils/cli/CommandLineTimeOutException.java
+++ b/src/main/java/org/apache/maven/shared/utils/cli/CommandLineTimeOutException.java
@@ -24,6 +24,7 @@ package org.apache.maven.shared.utils.cli;
  * @author Olivier Lamy
  *
  */
+@Deprecated
 public class CommandLineTimeOutException extends CommandLineException {
 
     private static final long serialVersionUID = 7322428741683224481L;

--- a/src/main/java/org/apache/maven/shared/utils/cli/CommandLineUtils.java
+++ b/src/main/java/org/apache/maven/shared/utils/cli/CommandLineUtils.java
@@ -37,6 +37,7 @@ import org.apache.maven.shared.utils.StringUtils;
 /**
  * @author <a href="mailto:trygvis@inamo.no">Trygve Laugst&oslash;l </a>
  */
+@Deprecated
 public abstract class CommandLineUtils {
 
     /**

--- a/src/main/java/org/apache/maven/shared/utils/cli/Commandline.java
+++ b/src/main/java/org/apache/maven/shared/utils/cli/Commandline.java
@@ -61,6 +61,7 @@ import org.apache.maven.shared.utils.cli.shell.Shell;
  * @author thomas.haas@softwired-inc.com
  * @author <a href="mailto:stefan.bodewig@epost.de">Stefan Bodewig</a>
  */
+@Deprecated
 public class Commandline implements Cloneable {
     private final List<Arg> arguments = new Vector<>();
 

--- a/src/main/java/org/apache/maven/shared/utils/cli/DefaultConsumer.java
+++ b/src/main/java/org/apache/maven/shared/utils/cli/DefaultConsumer.java
@@ -23,6 +23,7 @@ import java.io.IOException;
 /**
  * @author <a href="mailto:evenisse@apache.org">Emmanuel Venisse</a>
  */
+@Deprecated
 public class DefaultConsumer implements StreamConsumer {
 
     /**

--- a/src/main/java/org/apache/maven/shared/utils/cli/ShutdownHookUtils.java
+++ b/src/main/java/org/apache/maven/shared/utils/cli/ShutdownHookUtils.java
@@ -28,6 +28,7 @@ import java.security.AccessControlException;
  *
  * @author Kristian Rosenvold
  */
+@Deprecated
 public class ShutdownHookUtils {
 
     /**

--- a/src/main/java/org/apache/maven/shared/utils/cli/StreamConsumer.java
+++ b/src/main/java/org/apache/maven/shared/utils/cli/StreamConsumer.java
@@ -30,6 +30,7 @@ import java.io.IOException;
  * @author <a href="mailto:fvancea@maxiq.com">Florin Vancea</a>
  * @author <a href="mailto:pj@thoughtworks.com">Paul Julius</a>
  */
+@Deprecated
 public interface StreamConsumer {
     /**
      * Called when the StreamPumper pumps a line from the Stream.

--- a/src/main/java/org/apache/maven/shared/utils/cli/StreamPollFeeder.java
+++ b/src/main/java/org/apache/maven/shared/utils/cli/StreamPollFeeder.java
@@ -28,6 +28,7 @@ import java.util.Objects;
  *
  * @author <a href="mailto:trygvis@inamo.no">Trygve Laugst&oslash;l</a>
  */
+@Deprecated
 class StreamPollFeeder extends Thread {
 
     public static final int BUF_LEN = 80;

--- a/src/main/java/org/apache/maven/shared/utils/cli/StreamPumper.java
+++ b/src/main/java/org/apache/maven/shared/utils/cli/StreamPumper.java
@@ -33,6 +33,7 @@ import java.nio.charset.Charset;
  * @author <a href="mailto:fvancea@maxiq.com">Florin Vancea </a>
  * @author <a href="mailto:pj@thoughtworks.com">Paul Julius </a>
  */
+@Deprecated
 public class StreamPumper extends AbstractStreamHandler {
     private final BufferedReader in;
 

--- a/src/main/java/org/apache/maven/shared/utils/cli/javatool/AbstractJavaTool.java
+++ b/src/main/java/org/apache/maven/shared/utils/cli/javatool/AbstractJavaTool.java
@@ -40,6 +40,7 @@ import org.slf4j.LoggerFactory;
  * @since 0.5
  * @param <Request> Tool-specific request type
  */
+@Deprecated
 public abstract class AbstractJavaTool<Request extends JavaToolRequest> implements JavaTool<Request> {
     private final Logger logger = LoggerFactory.getLogger(getClass());
 

--- a/src/main/java/org/apache/maven/shared/utils/cli/javatool/AbstractJavaToolRequest.java
+++ b/src/main/java/org/apache/maven/shared/utils/cli/javatool/AbstractJavaToolRequest.java
@@ -26,6 +26,7 @@ import org.apache.maven.shared.utils.cli.StreamConsumer;
  * @author <a href="mailto:chemit@codelutin.com">Tony Chemit</a>
  * @since 0.5
  */
+@Deprecated
 public class AbstractJavaToolRequest implements JavaToolRequest {
 
     /**

--- a/src/main/java/org/apache/maven/shared/utils/cli/javatool/JavaTool.java
+++ b/src/main/java/org/apache/maven/shared/utils/cli/javatool/JavaTool.java
@@ -29,6 +29,7 @@ package org.apache.maven.shared.utils.cli.javatool;
  * @since 0.5
  * @param <Request> Tool-specific request type
  */
+@Deprecated
 public interface JavaTool<Request extends JavaToolRequest> {
 
     /**

--- a/src/main/java/org/apache/maven/shared/utils/cli/javatool/JavaToolException.java
+++ b/src/main/java/org/apache/maven/shared/utils/cli/javatool/JavaToolException.java
@@ -29,6 +29,7 @@ package org.apache.maven.shared.utils.cli.javatool;
  * @see JavaToolResult#getExitCode()
  * @since 0.5
  */
+@Deprecated
 public class JavaToolException extends Exception {
     private static final long serialVersionUID = 1L;
 

--- a/src/main/java/org/apache/maven/shared/utils/cli/javatool/JavaToolRequest.java
+++ b/src/main/java/org/apache/maven/shared/utils/cli/javatool/JavaToolRequest.java
@@ -26,6 +26,7 @@ import org.apache.maven.shared.utils.cli.StreamConsumer;
  * @author <a href="mailto:chemit@codelutin.com">Tony Chemit</a>
  * @since 0.5
  */
+@Deprecated
 public interface JavaToolRequest {
 
     /**

--- a/src/main/java/org/apache/maven/shared/utils/cli/javatool/JavaToolResult.java
+++ b/src/main/java/org/apache/maven/shared/utils/cli/javatool/JavaToolResult.java
@@ -27,6 +27,7 @@ import org.apache.maven.shared.utils.cli.Commandline;
  * @author <a href="mailto:chemit@codelutin.com">Tony Chemit</a>
  * @since 0.5
  */
+@Deprecated
 public class JavaToolResult {
     /**
      * The exception that prevented to execute the command line, will be <code>null</code> if jarSigner could be

--- a/src/main/java/org/apache/maven/shared/utils/cli/javatool/package-info.java
+++ b/src/main/java/org/apache/maven/shared/utils/cli/javatool/package-info.java
@@ -7,7 +7,7 @@
  * "License"); you may not use this file except in compliance
  * with the License.  You may obtain a copy of the License at
  *
- *   http://www.apache.org/licenses/LICENSE-2.0
+ *  http://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing,
  * software distributed under the License is distributed on an
@@ -16,36 +16,6 @@
  * specific language governing permissions and limitations
  * under the License.
  */
-package org.apache.maven.shared.utils.cli;
 
-import java.io.BufferedWriter;
-import java.io.IOException;
-import java.io.Writer;
-
-/**
- * @author <a href="mailto:jason@maven.org">Jason van Zyl</a>
- *
- */
 @Deprecated
-public class WriterStreamConsumer implements StreamConsumer {
-
-    private final BufferedWriter writer;
-
-    /**
-     * @param writer {@link Writer}
-     */
-    public WriterStreamConsumer(Writer writer) {
-        super();
-        this.writer = new BufferedWriter(writer);
-    }
-
-    /**
-     * {@inheritDoc}
-     */
-    @Override
-    public void consumeLine(String line) throws IOException {
-        this.writer.append(line);
-        this.writer.newLine();
-        this.writer.flush();
-    }
-}
+package org.apache.maven.shared.utils.cli.javatool;

--- a/src/main/java/org/apache/maven/shared/utils/cli/package-info.java
+++ b/src/main/java/org/apache/maven/shared/utils/cli/package-info.java
@@ -7,7 +7,7 @@
  * "License"); you may not use this file except in compliance
  * with the License.  You may obtain a copy of the License at
  *
- *   http://www.apache.org/licenses/LICENSE-2.0
+ *  http://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing,
  * software distributed under the License is distributed on an
@@ -16,36 +16,6 @@
  * specific language governing permissions and limitations
  * under the License.
  */
-package org.apache.maven.shared.utils.cli;
 
-import java.io.BufferedWriter;
-import java.io.IOException;
-import java.io.Writer;
-
-/**
- * @author <a href="mailto:jason@maven.org">Jason van Zyl</a>
- *
- */
 @Deprecated
-public class WriterStreamConsumer implements StreamConsumer {
-
-    private final BufferedWriter writer;
-
-    /**
-     * @param writer {@link Writer}
-     */
-    public WriterStreamConsumer(Writer writer) {
-        super();
-        this.writer = new BufferedWriter(writer);
-    }
-
-    /**
-     * {@inheritDoc}
-     */
-    @Override
-    public void consumeLine(String line) throws IOException {
-        this.writer.append(line);
-        this.writer.newLine();
-        this.writer.flush();
-    }
-}
+package org.apache.maven.shared.utils.cli;

--- a/src/main/java/org/apache/maven/shared/utils/cli/shell/BourneShell.java
+++ b/src/main/java/org/apache/maven/shared/utils/cli/shell/BourneShell.java
@@ -26,6 +26,7 @@ import org.apache.maven.shared.utils.Os;
 /**
  * @author Jason van Zyl
  */
+@Deprecated
 public class BourneShell extends Shell {
 
     /**

--- a/src/main/java/org/apache/maven/shared/utils/cli/shell/CmdShell.java
+++ b/src/main/java/org/apache/maven/shared/utils/cli/shell/CmdShell.java
@@ -27,6 +27,7 @@ import java.util.List;
  * @author <a href="mailto:carlos@apache.org">Carlos Sanchez</a>
  *
  */
+@Deprecated
 public class CmdShell extends Shell {
     /**
      * Create an instance of CmdShell.

--- a/src/main/java/org/apache/maven/shared/utils/cli/shell/Shell.java
+++ b/src/main/java/org/apache/maven/shared/utils/cli/shell/Shell.java
@@ -37,6 +37,7 @@ import org.apache.maven.shared.utils.StringUtils;
  * @author <a href="mailto:carlos@apache.org">Carlos Sanchez</a>
  *
  */
+@Deprecated
 public class Shell implements Cloneable {
     private static final char[] DEFAULT_QUOTING_TRIGGER_CHARS = {' '};
 

--- a/src/main/java/org/apache/maven/shared/utils/cli/shell/package-info.java
+++ b/src/main/java/org/apache/maven/shared/utils/cli/shell/package-info.java
@@ -7,7 +7,7 @@
  * "License"); you may not use this file except in compliance
  * with the License.  You may obtain a copy of the License at
  *
- *   http://www.apache.org/licenses/LICENSE-2.0
+ *  http://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing,
  * software distributed under the License is distributed on an
@@ -16,36 +16,6 @@
  * specific language governing permissions and limitations
  * under the License.
  */
-package org.apache.maven.shared.utils.cli;
 
-import java.io.BufferedWriter;
-import java.io.IOException;
-import java.io.Writer;
-
-/**
- * @author <a href="mailto:jason@maven.org">Jason van Zyl</a>
- *
- */
 @Deprecated
-public class WriterStreamConsumer implements StreamConsumer {
-
-    private final BufferedWriter writer;
-
-    /**
-     * @param writer {@link Writer}
-     */
-    public WriterStreamConsumer(Writer writer) {
-        super();
-        this.writer = new BufferedWriter(writer);
-    }
-
-    /**
-     * {@inheritDoc}
-     */
-    @Override
-    public void consumeLine(String line) throws IOException {
-        this.writer.append(line);
-        this.writer.newLine();
-        this.writer.flush();
-    }
-}
+package org.apache.maven.shared.utils.cli.shell;

--- a/src/main/java/org/apache/maven/shared/utils/introspection/ClassMap.java
+++ b/src/main/java/org/apache/maven/shared/utils/introspection/ClassMap.java
@@ -34,6 +34,7 @@ import java.util.Map;
  * @author <a href="mailto:geirm@optonline.net">Geir Magnusson Jr.</a>
  *
  */
+@Deprecated
 public class ClassMap {
     private static final class CacheMiss {}
 

--- a/src/main/java/org/apache/maven/shared/utils/introspection/IntrospectionException.java
+++ b/src/main/java/org/apache/maven/shared/utils/introspection/IntrospectionException.java
@@ -18,6 +18,7 @@
  */
 package org.apache.maven.shared.utils.introspection;
 
+@Deprecated
 class IntrospectionException extends Exception {
 
     /**

--- a/src/main/java/org/apache/maven/shared/utils/introspection/MethodMap.java
+++ b/src/main/java/org/apache/maven/shared/utils/introspection/MethodMap.java
@@ -34,6 +34,7 @@ import java.util.Map;
  * @author <a href="mailto:szegedia@freemail.hu">Attila Szegedi</a>
  *
  */
+@Deprecated
 class MethodMap {
     private static final int MORE_SPECIFIC = 0;
 

--- a/src/main/java/org/apache/maven/shared/utils/introspection/ReflectionValueExtractor.java
+++ b/src/main/java/org/apache/maven/shared/utils/introspection/ReflectionValueExtractor.java
@@ -42,6 +42,7 @@ import org.apache.maven.shared.utils.introspection.MethodMap.AmbiguousException;
  * @see <a href="http://struts.apache.org/1.x/struts-taglib/indexedprops.html">
  * http://struts.apache.org/1.x/struts-taglib/indexedprops.html</a>
  */
+@Deprecated
 public class ReflectionValueExtractor {
     private static final Class<?>[] CLASS_ARGS = new Class[0];
 

--- a/src/main/java/org/apache/maven/shared/utils/introspection/package-info.java
+++ b/src/main/java/org/apache/maven/shared/utils/introspection/package-info.java
@@ -7,7 +7,7 @@
  * "License"); you may not use this file except in compliance
  * with the License.  You may obtain a copy of the License at
  *
- *   http://www.apache.org/licenses/LICENSE-2.0
+ *  http://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing,
  * software distributed under the License is distributed on an
@@ -16,36 +16,6 @@
  * specific language governing permissions and limitations
  * under the License.
  */
-package org.apache.maven.shared.utils.cli;
 
-import java.io.BufferedWriter;
-import java.io.IOException;
-import java.io.Writer;
-
-/**
- * @author <a href="mailto:jason@maven.org">Jason van Zyl</a>
- *
- */
 @Deprecated
-public class WriterStreamConsumer implements StreamConsumer {
-
-    private final BufferedWriter writer;
-
-    /**
-     * @param writer {@link Writer}
-     */
-    public WriterStreamConsumer(Writer writer) {
-        super();
-        this.writer = new BufferedWriter(writer);
-    }
-
-    /**
-     * {@inheritDoc}
-     */
-    @Override
-    public void consumeLine(String line) throws IOException {
-        this.writer.append(line);
-        this.writer.newLine();
-        this.writer.flush();
-    }
-}
+package org.apache.maven.shared.utils.introspection;

--- a/src/main/java/org/apache/maven/shared/utils/io/FileUtils.java
+++ b/src/main/java/org/apache/maven/shared/utils/io/FileUtils.java
@@ -90,6 +90,7 @@ import org.apache.maven.shared.utils.StringUtils;
  * @author <a href="mailto:peter@apache.org">Peter Donald</a>
  * @author <a href="mailto:jefft@apache.org">Jeff Turner</a>
  */
+@Deprecated
 public class FileUtils {
     /**
      * protected constructor.

--- a/src/main/java/org/apache/maven/shared/utils/io/IOUtil.java
+++ b/src/main/java/org/apache/maven/shared/utils/io/IOUtil.java
@@ -80,6 +80,7 @@ import java.nio.channels.Channel;
  * @version CVS $Revision$ $Date$
  *
  */
+@Deprecated
 public final class IOUtil
 /*
  * Behold, intrepid explorers; a map of this class:

--- a/src/main/java/org/apache/maven/shared/utils/io/package-info.java
+++ b/src/main/java/org/apache/maven/shared/utils/io/package-info.java
@@ -7,7 +7,7 @@
  * "License"); you may not use this file except in compliance
  * with the License.  You may obtain a copy of the License at
  *
- *   http://www.apache.org/licenses/LICENSE-2.0
+ *  http://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing,
  * software distributed under the License is distributed on an
@@ -16,36 +16,6 @@
  * specific language governing permissions and limitations
  * under the License.
  */
-package org.apache.maven.shared.utils.cli;
 
-import java.io.BufferedWriter;
-import java.io.IOException;
-import java.io.Writer;
-
-/**
- * @author <a href="mailto:jason@maven.org">Jason van Zyl</a>
- *
- */
 @Deprecated
-public class WriterStreamConsumer implements StreamConsumer {
-
-    private final BufferedWriter writer;
-
-    /**
-     * @param writer {@link Writer}
-     */
-    public WriterStreamConsumer(Writer writer) {
-        super();
-        this.writer = new BufferedWriter(writer);
-    }
-
-    /**
-     * {@inheritDoc}
-     */
-    @Override
-    public void consumeLine(String line) throws IOException {
-        this.writer.append(line);
-        this.writer.newLine();
-        this.writer.flush();
-    }
-}
+package org.apache.maven.shared.utils.io;

--- a/src/main/java/org/apache/maven/shared/utils/logging/AnsiMessageBuilder.java
+++ b/src/main/java/org/apache/maven/shared/utils/logging/AnsiMessageBuilder.java
@@ -24,6 +24,7 @@ import org.fusesource.jansi.Ansi;
  * Message builder implementation that supports ANSI colors through
  * <a href="http://fusesource.github.io/jansi/">Jansi</a> with configurable styles through {@link Style}.
  */
+@Deprecated
 class AnsiMessageBuilder implements MessageBuilder, LoggerLevelRenderer {
     private Ansi ansi;
 

--- a/src/main/java/org/apache/maven/shared/utils/logging/LoggerLevelRenderer.java
+++ b/src/main/java/org/apache/maven/shared/utils/logging/LoggerLevelRenderer.java
@@ -24,6 +24,7 @@ package org.apache.maven.shared.utils.logging;
  *
  * @since 3.2.0
  */
+@Deprecated
 public interface LoggerLevelRenderer {
     /**
      * Render a message at DEBUG level.

--- a/src/main/java/org/apache/maven/shared/utils/logging/MessageBuilder.java
+++ b/src/main/java/org/apache/maven/shared/utils/logging/MessageBuilder.java
@@ -29,6 +29,7 @@ import java.util.Formatter;
  * @see MessageUtils
  * @since 3.1.0
  */
+@Deprecated
 public interface MessageBuilder {
     /**
      * Append message content in success style.

--- a/src/main/java/org/apache/maven/shared/utils/logging/MessageUtils.java
+++ b/src/main/java/org/apache/maven/shared/utils/logging/MessageUtils.java
@@ -30,6 +30,7 @@ import org.fusesource.jansi.AnsiMode;
  * <a href="https://en.wikipedia.org/wiki/ANSI_escape_code#Colors">ANSI colors</a> on any platform.
  * @since 3.1.0
  */
+@Deprecated
 public class MessageUtils {
     private static final boolean JANSI;
 

--- a/src/main/java/org/apache/maven/shared/utils/logging/PlainMessageBuilder.java
+++ b/src/main/java/org/apache/maven/shared/utils/logging/PlainMessageBuilder.java
@@ -21,6 +21,7 @@ package org.apache.maven.shared.utils.logging;
 /**
  * Message builder implementation that just ignores styling, for Maven version earlier than 3.5.0.
  */
+@Deprecated
 class PlainMessageBuilder implements MessageBuilder, LoggerLevelRenderer {
     private StringBuilder buffer;
 

--- a/src/main/java/org/apache/maven/shared/utils/logging/Style.java
+++ b/src/main/java/org/apache/maven/shared/utils/logging/Style.java
@@ -27,6 +27,7 @@ import org.fusesource.jansi.Ansi.Color;
  * Configurable message styles.
  * @since 3.1.0
  */
+@Deprecated
 enum Style {
     DEBUG("bold,cyan"),
     INFO("bold,blue"),

--- a/src/main/java/org/apache/maven/shared/utils/logging/package-info.java
+++ b/src/main/java/org/apache/maven/shared/utils/logging/package-info.java
@@ -17,35 +17,5 @@
  * under the License.
  */
 
-/**
- * An API to write Maven messages to console with styled color content, consistently across whole
- * Maven ecosystem (Maven itself or any plugin or extension).
- * <p>
- * Messages are built with instances of {@code MessageBuilder}
- * which provides a fluent API, while error level are colored by slf4j provider with
- * {@code LoggerLevelRenderer}.
- * <p>
- * {@code MessageUtils} gives access to these builders.
- * <p>
- * Plugins can use this API with any Maven version: color
- * just won't be activated when run with Maven versions older than 3.5.0.
- * <p>
- * Styles are:<ul>
- * <li><code>debug</code>, <code>info</code>, <code>warning</code> and <code>error</code> for
- * logger level rendering,</li>
- * <li><code>success</code>, <code>warning</code>, <code>failure</code>, <code>strong</code>, <code>mojo</code>
- * and <code>project</code> for message content</li>
- * </ul>
- * Default styles colors can be overridden through system properties, that can be set in <code>MAVEN_OPTS</code>
- * environment variable (eventually in <code>.mavenrc</code> script):<ul>
- * <li>system properties are named <code>style.&lt;style name&gt;</code>,</li>
- * <li>values are comma separated combination of <code>bold</code>, <code>&lt;color&gt;</code> and
- * <code>bg&lt;color&gt;</code> (for background), where <code>&lt;color&gt;</code> is
- * an <a href="https://en.wikipedia.org/wiki/ANSI_escape_code#Colors">ANSI color</a>: <code>black</code>,
- * <code>red</code>, <code>green</code>, <code>yellow</code>, <code>blue</code>, <code>magenta</code>,
- * <code>cyan</code> or <code>white</code>, eventually with <code>bright</code> prefix</li>
- * </ul>
- *
- * @since 3.1.0
- */
+@Deprecated
 package org.apache.maven.shared.utils.logging;

--- a/src/main/java/org/apache/maven/shared/utils/package-info.java
+++ b/src/main/java/org/apache/maven/shared/utils/package-info.java
@@ -7,7 +7,7 @@
  * "License"); you may not use this file except in compliance
  * with the License.  You may obtain a copy of the License at
  *
- *   http://www.apache.org/licenses/LICENSE-2.0
+ *  http://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing,
  * software distributed under the License is distributed on an
@@ -16,36 +16,6 @@
  * specific language governing permissions and limitations
  * under the License.
  */
-package org.apache.maven.shared.utils.cli;
 
-import java.io.BufferedWriter;
-import java.io.IOException;
-import java.io.Writer;
-
-/**
- * @author <a href="mailto:jason@maven.org">Jason van Zyl</a>
- *
- */
 @Deprecated
-public class WriterStreamConsumer implements StreamConsumer {
-
-    private final BufferedWriter writer;
-
-    /**
-     * @param writer {@link Writer}
-     */
-    public WriterStreamConsumer(Writer writer) {
-        super();
-        this.writer = new BufferedWriter(writer);
-    }
-
-    /**
-     * {@inheritDoc}
-     */
-    @Override
-    public void consumeLine(String line) throws IOException {
-        this.writer.append(line);
-        this.writer.newLine();
-        this.writer.flush();
-    }
-}
+package org.apache.maven.shared.utils;

--- a/src/main/java/org/apache/maven/shared/utils/xml/PrettyPrintXMLWriter.java
+++ b/src/main/java/org/apache/maven/shared/utils/xml/PrettyPrintXMLWriter.java
@@ -28,6 +28,7 @@ import java.util.ArrayList;
  *
  * @author kama
  */
+@Deprecated
 public class PrettyPrintXMLWriter implements XMLWriter {
     private static final char[] CLOSE_1 = "/>".toCharArray();
 

--- a/src/main/java/org/apache/maven/shared/utils/xml/XMLEncode.java
+++ b/src/main/java/org/apache/maven/shared/utils/xml/XMLEncode.java
@@ -26,6 +26,7 @@ import java.io.Writer;
  * This is all about the special characters &amp; and &lt;, and for attributes
  * &quot; and &apos;. These must be encoded/decoded from/to XML.
  */
+@Deprecated
 final class XMLEncode {
 
     private static final int CDATA_BLOCK_THRESHOLD_LENGTH = 12;

--- a/src/main/java/org/apache/maven/shared/utils/xml/XMLWriter.java
+++ b/src/main/java/org/apache/maven/shared/utils/xml/XMLWriter.java
@@ -24,6 +24,7 @@ import java.io.IOException;
  * Interface for tools writing XML files.
  * XMLWriters are not thread safe and must not be accessed concurrently.
  */
+@Deprecated
 public interface XMLWriter {
 
     /**

--- a/src/main/java/org/apache/maven/shared/utils/xml/XmlWriterUtil.java
+++ b/src/main/java/org/apache/maven/shared/utils/xml/XmlWriterUtil.java
@@ -28,6 +28,7 @@ import org.apache.maven.shared.utils.StringUtils;
  * @author <a href="mailto:vincent.siveton@gmail.com">Vincent Siveton</a>
  *
  */
+@Deprecated
 public class XmlWriterUtil {
     /** The vm line separator */
     public static final String LS = System.getProperty("line.separator");

--- a/src/main/java/org/apache/maven/shared/utils/xml/Xpp3Dom.java
+++ b/src/main/java/org/apache/maven/shared/utils/xml/Xpp3Dom.java
@@ -34,6 +34,7 @@ import java.util.Map;
  *
  * @author Kristian Rosenvold
  */
+@Deprecated
 public class Xpp3Dom implements Iterable<Xpp3Dom> {
     private static final long serialVersionUID = 2567894443061173996L;
 

--- a/src/main/java/org/apache/maven/shared/utils/xml/Xpp3DomBuilder.java
+++ b/src/main/java/org/apache/maven/shared/utils/xml/Xpp3DomBuilder.java
@@ -39,6 +39,7 @@ import org.xml.sax.helpers.DefaultHandler;
 /**
  * @author Kristian Rosenvold
  */
+@Deprecated
 public class Xpp3DomBuilder {
 
     /**

--- a/src/main/java/org/apache/maven/shared/utils/xml/Xpp3DomUtils.java
+++ b/src/main/java/org/apache/maven/shared/utils/xml/Xpp3DomUtils.java
@@ -26,6 +26,7 @@ import java.util.Map;
 /**
  *
  */
+@Deprecated
 public class Xpp3DomUtils {
     /**
      * @param dominant {@link Xpp3Dom}

--- a/src/main/java/org/apache/maven/shared/utils/xml/Xpp3DomWriter.java
+++ b/src/main/java/org/apache/maven/shared/utils/xml/Xpp3DomWriter.java
@@ -25,6 +25,7 @@ import java.io.Writer;
 /**
  * @author Brett Porter
  */
+@Deprecated
 public class Xpp3DomWriter {
     /**
      * @param writer {@link Writer}

--- a/src/main/java/org/apache/maven/shared/utils/xml/package-info.java
+++ b/src/main/java/org/apache/maven/shared/utils/xml/package-info.java
@@ -7,7 +7,7 @@
  * "License"); you may not use this file except in compliance
  * with the License.  You may obtain a copy of the License at
  *
- *   http://www.apache.org/licenses/LICENSE-2.0
+ *  http://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing,
  * software distributed under the License is distributed on an
@@ -16,36 +16,6 @@
  * specific language governing permissions and limitations
  * under the License.
  */
-package org.apache.maven.shared.utils.cli;
 
-import java.io.BufferedWriter;
-import java.io.IOException;
-import java.io.Writer;
-
-/**
- * @author <a href="mailto:jason@maven.org">Jason van Zyl</a>
- *
- */
 @Deprecated
-public class WriterStreamConsumer implements StreamConsumer {
-
-    private final BufferedWriter writer;
-
-    /**
-     * @param writer {@link Writer}
-     */
-    public WriterStreamConsumer(Writer writer) {
-        super();
-        this.writer = new BufferedWriter(writer);
-    }
-
-    /**
-     * {@inheritDoc}
-     */
-    @Override
-    public void consumeLine(String line) throws IOException {
-        this.writer.append(line);
-        this.writer.newLine();
-        this.writer.flush();
-    }
-}
+package org.apache.maven.shared.utils.xml;

--- a/src/main/java/org/apache/maven/shared/utils/xml/pull/XmlPullParserException.java
+++ b/src/main/java/org/apache/maven/shared/utils/xml/pull/XmlPullParserException.java
@@ -22,6 +22,7 @@ import java.io.IOException;
 
 import org.xml.sax.SAXException;
 
+@Deprecated
 public class XmlPullParserException extends RuntimeException {
 
     private static final long serialVersionUID = 117075811816936575L;

--- a/src/main/java/org/apache/maven/shared/utils/xml/pull/package-info.java
+++ b/src/main/java/org/apache/maven/shared/utils/xml/pull/package-info.java
@@ -7,7 +7,7 @@
  * "License"); you may not use this file except in compliance
  * with the License.  You may obtain a copy of the License at
  *
- *   http://www.apache.org/licenses/LICENSE-2.0
+ *  http://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing,
  * software distributed under the License is distributed on an
@@ -16,36 +16,6 @@
  * specific language governing permissions and limitations
  * under the License.
  */
-package org.apache.maven.shared.utils.cli;
 
-import java.io.BufferedWriter;
-import java.io.IOException;
-import java.io.Writer;
-
-/**
- * @author <a href="mailto:jason@maven.org">Jason van Zyl</a>
- *
- */
 @Deprecated
-public class WriterStreamConsumer implements StreamConsumer {
-
-    private final BufferedWriter writer;
-
-    /**
-     * @param writer {@link Writer}
-     */
-    public WriterStreamConsumer(Writer writer) {
-        super();
-        this.writer = new BufferedWriter(writer);
-    }
-
-    /**
-     * {@inheritDoc}
-     */
-    @Override
-    public void consumeLine(String line) throws IOException {
-        this.writer.append(line);
-        this.writer.newLine();
-        this.writer.flush();
-    }
-}
+package org.apache.maven.shared.utils.xml.pull;


### PR DESCRIPTION
JIRA issue: https://issues.apache.org/jira/browse/MSHARED-1269

Maven-shared-utils was created so that plexus-utils could be deprecated on kinda _come back_ into the maven land.  However, this did never happened and we end-up with the exact same library duplicated and duplicate maintenance effort.

The only problematic point is the `org.apache.maven.shared.utils.logging` package which is used by several components and does not exists in plexus-utils.  Maven 4 provides a similar API already with the `MessageBuilderFactory` service which allows the creation of `MessageBuilder`.  I thus propose to get rid completely of maven-shared-utils.

The [maven PR](https://github.com/apache/maven/pull/1158) get rid of maven-shared-utils in maven core.