### PR TITLE
Display Unicode unescaped when test fails

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -109,12 +109,6 @@
       <scope>test</scope>
     </dependency>
     <dependency>
-      <groupId>org.apache.commons</groupId>
-      <artifactId>commons-text</artifactId>
-      <version>1.11.0</version>
-      <scope>test</scope>
-    </dependency>
-    <dependency>
       <groupId>com.google.code.findbugs</groupId>
       <artifactId>jsr305</artifactId>
       <version>3.0.2</version>

--- a/src/test/java/org/apache/maven/shared/utils/CaseTest.java
+++ b/src/test/java/org/apache/maven/shared/utils/CaseTest.java
@@ -71,18 +71,25 @@ public class CaseTest extends Assert {
         final String iIıİ = "iIıİ";
 
         // check source encoding doesn't wreak havoc */
-        assertEquals( "misc i directly in (UTF-8) source", iIıİ, "" + DOTTED_i + DOTLESS_I + DOTLESS_i + DOTTED_I );
+        assertEquals("misc i directly in (UTF-8) source", iIıİ, "" + DOTTED_i + DOTLESS_I + DOTLESS_i + DOTTED_I);
 
         // check toUpperCase and toLowerCase difference with turkish and english locales
-        assertEquals( "'iIıİ'.toUpperCase('tr')=='İIIİ'", "" + DOTTED_I + DOTLESS_I + DOTLESS_I + DOTTED_I,
-                iIıİ.toUpperCase(LOCALE_TURKISH) );
-        assertEquals( "'iIıİ'.toLowerCase('tr')=='iııi'", "" + DOTTED_i + DOTLESS_i + DOTLESS_i + DOTTED_i,
-                iIıİ.toLowerCase(LOCALE_TURKISH) );
-        assertEquals( "'iIıİ'.toUpperCase('en')=='IIIİ'", "" + DOTLESS_I + DOTLESS_I + DOTLESS_I + DOTTED_I,
-                iIıİ.toUpperCase(Locale.ENGLISH) );
+        assertEquals(
+                "'iIıİ'.toUpperCase('tr')=='İIIİ'",
+                "" + DOTTED_I + DOTLESS_I + DOTLESS_I + DOTTED_I,
+                iIıİ.toUpperCase(LOCALE_TURKISH));
+        assertEquals(
+                "'iIıİ'.toLowerCase('tr')=='iııi'",
+                "" + DOTTED_i + DOTLESS_i + DOTLESS_i + DOTTED_i,
+                iIıİ.toLowerCase(LOCALE_TURKISH));
+        assertEquals(
+                "'iIıİ'.toUpperCase('en')=='IIIİ'",
+                "" + DOTLESS_I + DOTLESS_I + DOTLESS_I + DOTTED_I,
+                iIıİ.toUpperCase(Locale.ENGLISH));
         String lower = iIıİ.toLowerCase(Locale.ENGLISH); // on some platforms, ends with extra COMBINED DOT ABOVE
-        String expected = "" + DOTTED_i + DOTTED_i + DOTLESS_i + DOTTED_i + (lower.length() > 4 ? COMBINING_DOT_ABOVE : "");
-        assertEquals( "'iIıİ'.toLowerCase('en')=='iiıi'", expected, lower );
+        String expected =
+                "" + DOTTED_i + DOTTED_i + DOTLESS_i + DOTTED_i + (lower.length() > 4 ? COMBINING_DOT_ABOVE : "");
+        assertEquals("'iIıİ'.toLowerCase('en')=='iiıi'", expected, lower);
 
         // check equalsIgnoreCase() , which has no locale
         for (int i = 0; i < iIıİ.length(); i++) {

--- a/src/test/java/org/apache/maven/shared/utils/CaseTest.java
+++ b/src/test/java/org/apache/maven/shared/utils/CaseTest.java
@@ -20,10 +20,8 @@ package org.apache.maven.shared.utils;
 
 import java.util.Locale;
 
-import org.apache.commons.text.StringEscapeUtils;
 import org.junit.AfterClass;
 import org.junit.Assert;
-import org.junit.ComparisonFailure;
 import org.junit.Test;
 
 /**
@@ -72,28 +70,19 @@ public class CaseTest extends Assert {
 
         final String iIıİ = "iIıİ";
 
-        // check source encoding doesn't wreck havoc */
-        assertUnicodeEquals(
-                "misc i directly in (UTF-8) source", iIıİ, "" + DOTTED_i + DOTLESS_I + DOTLESS_i + DOTTED_I);
+        // check source encoding doesn't wreak havoc */
+        assertEquals( "misc i directly in (UTF-8) source", iIıİ, "" + DOTTED_i + DOTLESS_I + DOTLESS_i + DOTTED_I );
 
         // check toUpperCase and toLowerCase difference with turkish and english locales
-        assertUnicodeEquals(
-                "'iIıİ'.toUpperCase('tr')=='İIIİ'",
-                "" + DOTTED_I + DOTLESS_I + DOTLESS_I + DOTTED_I,
-                iIıİ.toUpperCase(LOCALE_TURKISH));
-        assertUnicodeEquals(
-                "'iIıİ'.toLowerCase('tr')=='iııi'",
-                "" + DOTTED_i + DOTLESS_i + DOTLESS_i + DOTTED_i,
-                iIıİ.toLowerCase(LOCALE_TURKISH));
-        assertUnicodeEquals(
-                "'iIıİ'.toUpperCase('en')=='IIIİ'",
-                "" + DOTLESS_I + DOTLESS_I + DOTLESS_I + DOTTED_I,
-                iIıİ.toUpperCase(Locale.ENGLISH));
+        assertEquals( "'iIıİ'.toUpperCase('tr')=='İIIİ'", "" + DOTTED_I + DOTLESS_I + DOTLESS_I + DOTTED_I,
+                iIıİ.toUpperCase(LOCALE_TURKISH) );
+        assertEquals( "'iIıİ'.toLowerCase('tr')=='iııi'", "" + DOTTED_i + DOTLESS_i + DOTLESS_i + DOTTED_i,
+                iIıİ.toLowerCase(LOCALE_TURKISH) );
+        assertEquals( "'iIıİ'.toUpperCase('en')=='IIIİ'", "" + DOTLESS_I + DOTLESS_I + DOTLESS_I + DOTTED_I,
+                iIıİ.toUpperCase(Locale.ENGLISH) );
         String lower = iIıİ.toLowerCase(Locale.ENGLISH); // on some platforms, ends with extra COMBINED DOT ABOVE
-        assertUnicodeEquals(
-                "'iIıİ'.toLowerCase('en')=='iiıi'",
-                "" + DOTTED_i + DOTTED_i + DOTLESS_i + DOTTED_i + (lower.length() > 4 ? COMBINING_DOT_ABOVE : ""),
-                lower);
+        String expected = "" + DOTTED_i + DOTTED_i + DOTLESS_i + DOTTED_i + (lower.length() > 4 ? COMBINING_DOT_ABOVE : "");
+        assertEquals( "'iIıİ'.toLowerCase('en')=='iiıi'", expected, lower );
 
         // check equalsIgnoreCase() , which has no locale
         for (int i = 0; i < iIıİ.length(); i++) {
@@ -107,21 +96,6 @@ public class CaseTest extends Assert {
 
             assertTrue("'" + current + "'.equalsIgnoreCase('" + iIıİ + "')", current.equalsIgnoreCase(iIıİ));
         }
-    }
-
-    /**
-     * Assert equals, and in case the result isn't as expected, display content unicode-escaped.
-     * @param message
-     * @param expected
-     * @param actual
-     */
-    private void assertUnicodeEquals(String message, String expected, String actual) {
-        if (expected.equals(actual)) {
-            return;
-        }
-
-        throw new ComparisonFailure(
-                message, StringEscapeUtils.escapeJava(expected), StringEscapeUtils.escapeJava(actual));
     }
 
     /**


### PR DESCRIPTION
Minor change that removes two dependencies, one direct and one transitive, from the test tree.

In 2025 we can assume that computers know how to display non-ASCII letters like the Turkish dotted I, and that's easier to debug in event of failure than a Unicode escape. 