### PR TITLE
Remove a lot of escaping logic that's unreachable and never used

### DIFF
--- a/src/main/java/org/apache/maven/shared/utils/cli/shell/BourneShell.java
+++ b/src/main/java/org/apache/maven/shared/utils/cli/shell/BourneShell.java
@@ -34,11 +34,6 @@ public class BourneShell extends Shell {
     public BourneShell() {
         setUnconditionalQuoting(true);
         setShellCommand("/bin/sh");
-        setArgumentQuoteDelimiter('\'');
-        setExecutableQuoteDelimiter('\'');
-        setSingleQuotedArgumentEscaped(true);
-        setSingleQuotedExecutableEscaped(false);
-        setQuotedExecutableEnabled(true);
     }
 
     /**

--- a/src/main/java/org/apache/maven/shared/utils/cli/shell/BourneShell.java
+++ b/src/main/java/org/apache/maven/shared/utils/cli/shell/BourneShell.java
@@ -32,7 +32,6 @@ public class BourneShell extends Shell {
      * Create instance of BourneShell.
      */
     public BourneShell() {
-        setUnconditionalQuoting(true);
         setShellCommand("/bin/sh");
     }
 

--- a/src/main/java/org/apache/maven/shared/utils/cli/shell/BourneShell.java
+++ b/src/main/java/org/apache/maven/shared/utils/cli/shell/BourneShell.java
@@ -39,6 +39,7 @@ public class BourneShell extends Shell {
     /**
      * {@inheritDoc}
      */
+    @Override
     public String getExecutable() {
         if (Os.isFamily(Os.FAMILY_WINDOWS)) {
             return super.getExecutable();
@@ -50,6 +51,7 @@ public class BourneShell extends Shell {
     /**
      * {@inheritDoc}
      */
+    @Override
     public List<String> getShellArgsList() {
         List<String> shellArgs = new ArrayList<>();
         List<String> existingShellArgs = super.getShellArgsList();
@@ -66,6 +68,7 @@ public class BourneShell extends Shell {
     /**
      * {@inheritDoc}
      */
+    @Override
     public String[] getShellArgs() {
         String[] shellArgs = super.getShellArgs();
         if (shellArgs == null) {
@@ -87,6 +90,7 @@ public class BourneShell extends Shell {
     /**
      * {@inheritDoc}
      */
+    @Override
     protected String getExecutionPreamble() {
         if (getWorkingDirectoryAsString() == null) {
             return null;
@@ -113,6 +117,7 @@ public class BourneShell extends Shell {
      * @param path not null path
      * @return the path unified correctly for the Bourne shell
      */
+    @Override
     protected String quoteOneItem(String path, boolean isExecutable) {
         if (path == null) {
             return null;

--- a/src/main/java/org/apache/maven/shared/utils/cli/shell/CmdShell.java
+++ b/src/main/java/org/apache/maven/shared/utils/cli/shell/CmdShell.java
@@ -32,7 +32,6 @@ public class CmdShell extends Shell {
      */
     public CmdShell() {
         setShellCommand("cmd.exe");
-        setQuotedExecutableEnabled(true);
         setShellArgs(new String[] {"/X", "/C"});
     }
 

--- a/src/main/java/org/apache/maven/shared/utils/cli/shell/CmdShell.java
+++ b/src/main/java/org/apache/maven/shared/utils/cli/shell/CmdShell.java
@@ -76,6 +76,7 @@ public class CmdShell extends Shell {
      * @param arguments the arguments for the executable
      * @return the resulting command line
      */
+    @Override
     public List<String> getCommandLine(String executable, String... arguments) {
         StringBuilder sb = new StringBuilder();
         sb.append('"');

--- a/src/main/java/org/apache/maven/shared/utils/cli/shell/Shell.java
+++ b/src/main/java/org/apache/maven/shared/utils/cli/shell/Shell.java
@@ -130,7 +130,7 @@ public class Shell {
                 sb.append(' ');
             }
 
-            if (isQuotedArgumentsEnabled()) {
+            if (quotedArgumentsEnabled) {
                 sb.append(quoteOneItem(argument, false));
             } else {
                 sb.append(argument);
@@ -198,10 +198,6 @@ public class Shell {
      */
     public void setQuotedArgumentsEnabled(boolean quotedArgumentsEnabled) {
         this.quotedArgumentsEnabled = quotedArgumentsEnabled;
-    }
-
-    private boolean isQuotedArgumentsEnabled() {
-        return quotedArgumentsEnabled;
     }
 
     /**

--- a/src/main/java/org/apache/maven/shared/utils/cli/shell/Shell.java
+++ b/src/main/java/org/apache/maven/shared/utils/cli/shell/Shell.java
@@ -132,11 +132,7 @@ public class Shell {
                 sb.append(preamble);
             }
 
-            if (isQuotedExecutableEnabled()) {
-                sb.append(quoteOneItem(executableParameter, true));
-            } else {
-                sb.append(executableParameter);
-            }
+            sb.append(quoteOneItem(executableParameter, true));
         }
         for (String argument : argumentsParameter) {
             if (sb.length() > 0) {
@@ -213,12 +209,8 @@ public class Shell {
         this.quotedArgumentsEnabled = quotedArgumentsEnabled;
     }
 
-    boolean isQuotedArgumentsEnabled() {
+    private boolean isQuotedArgumentsEnabled() {
         return quotedArgumentsEnabled;
-    }
-
-    boolean isQuotedExecutableEnabled() {
-        return true;
     }
 
     /**

--- a/src/main/java/org/apache/maven/shared/utils/cli/shell/Shell.java
+++ b/src/main/java/org/apache/maven/shared/utils/cli/shell/Shell.java
@@ -51,15 +51,7 @@ public class Shell {
 
     private String workingDir;
 
-    private boolean quotedExecutableEnabled = true;
-
-    private boolean singleQuotedArgumentEscaped = false;
-
-    private boolean singleQuotedExecutableEscaped = false;
-
-    private char argQuoteDelimiter = '\"';
-
-    private char exeQuoteDelimiter = '\"';
+    private final boolean singleQuotedArgumentEscaped = false;
 
     /**
      * Set the command to execute the shell (e.g. COMMAND.COM, /bin/bash,...).
@@ -104,10 +96,10 @@ public class Shell {
     }
 
     protected String quoteOneItem(String inputString, boolean isExecutable) {
-        char[] escapeChars = getEscapeChars(isSingleQuotedExecutableEscaped(), isDoubleQuotedExecutableEscaped());
+        char[] escapeChars = {};
         return StringUtils.quoteAndEscape(
                 inputString,
-                isExecutable ? getExecutableQuoteDelimiter() : getArgumentQuoteDelimiter(),
+                isExecutable ? '\"' : '\"',
                 escapeChars,
                 getQuotingTriggerChars(),
                 '\\',
@@ -171,22 +163,6 @@ public class Shell {
         return null;
     }
 
-    char[] getEscapeChars(boolean includeSingleQuote, boolean includeDoubleQuote) {
-        StringBuilder buf = new StringBuilder(2);
-        if (includeSingleQuote) {
-            buf.append('\'');
-        }
-
-        if (includeDoubleQuote) {
-            buf.append('\"');
-        }
-
-        char[] result = new char[buf.length()];
-        buf.getChars(0, buf.length(), result, 0);
-
-        return result;
-    }
-
     /**
      * @return false in all cases
      */
@@ -199,36 +175,6 @@ public class Shell {
      */
     protected boolean isSingleQuotedArgumentEscaped() {
         return singleQuotedArgumentEscaped;
-    }
-
-    boolean isDoubleQuotedExecutableEscaped() {
-        return false;
-    }
-
-    boolean isSingleQuotedExecutableEscaped() {
-        return singleQuotedExecutableEscaped;
-    }
-
-    /**
-     * @param argQuoteDelimiterParameter {@link #argQuoteDelimiter}
-     */
-    void setArgumentQuoteDelimiter(char argQuoteDelimiterParameter) {
-        this.argQuoteDelimiter = argQuoteDelimiterParameter;
-    }
-
-    char getArgumentQuoteDelimiter() {
-        return argQuoteDelimiter;
-    }
-
-    /**
-     * @param exeQuoteDelimiterParameter {@link #exeQuoteDelimiter}
-     */
-    void setExecutableQuoteDelimiter(char exeQuoteDelimiterParameter) {
-        this.exeQuoteDelimiter = exeQuoteDelimiterParameter;
-    }
-
-    char getExecutableQuoteDelimiter() {
-        return exeQuoteDelimiter;
     }
 
     /**
@@ -271,12 +217,8 @@ public class Shell {
         return quotedArgumentsEnabled;
     }
 
-    void setQuotedExecutableEnabled(boolean quotedExecutableEnabled) {
-        this.quotedExecutableEnabled = quotedExecutableEnabled;
-    }
-
     boolean isQuotedExecutableEnabled() {
-        return quotedExecutableEnabled;
+        return true;
     }
 
     /**
@@ -329,14 +271,6 @@ public class Shell {
 
     String getWorkingDirectoryAsString() {
         return workingDir;
-    }
-
-    void setSingleQuotedArgumentEscaped(boolean singleQuotedArgumentEscaped) {
-        this.singleQuotedArgumentEscaped = singleQuotedArgumentEscaped;
-    }
-
-    void setSingleQuotedExecutableEscaped(boolean singleQuotedExecutableEscaped) {
-        this.singleQuotedExecutableEscaped = singleQuotedExecutableEscaped;
     }
 
     public boolean isUnconditionalQuoting() {

--- a/src/main/java/org/apache/maven/shared/utils/cli/shell/Shell.java
+++ b/src/main/java/org/apache/maven/shared/utils/cli/shell/Shell.java
@@ -23,8 +23,6 @@ import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.List;
 
-import org.apache.maven.shared.utils.StringUtils;
-
 /**
  * Class that abstracts the Shell functionality,
  * with subclasses for shells that behave particularly, like
@@ -96,14 +94,7 @@ public class Shell {
     }
 
     protected String quoteOneItem(String inputString, boolean isExecutable) {
-        char[] escapeChars = {};
-        return StringUtils.quoteAndEscape(
-                inputString,
-                isExecutable ? '\"' : '\"',
-                escapeChars,
-                getQuotingTriggerChars(),
-                '\\',
-                unconditionalQuoting);
+        return inputString;
     }
 
     /**


### PR DESCRIPTION
One of those threads you pull on that unravels half the ball. I could remove more but I'm leaving open the possibility that some public and protected methods are invoked or overridden outside this repo. This is a pretty strong case of YAGNI, and we're even less likely to need this in the future, since Java 11+ provide much better options for doing what these classes do.