### PR TITLE
StringUtils.chopNewline(''): prevent StringIndexOutOfBoundsException

### DIFF
--- a/src/main/java/org/apache/maven/shared/utils/StringUtils.java
+++ b/src/main/java/org/apache/maven/shared/utils/StringUtils.java
@@ -963,6 +963,9 @@ public class StringUtils {
      */
     @NonNull
     public static String chopNewline(@NonNull String str) {
+        if (str.isEmpty()) {
+            return "";
+        }
         int lastIdx = str.length() - 1;
         char last = str.charAt(lastIdx);
         if (last == '\n') {

--- a/src/test/java/org/apache/maven/shared/utils/StringUtilsTest.java
+++ b/src/test/java/org/apache/maven/shared/utils/StringUtilsTest.java
@@ -251,6 +251,11 @@ public class StringUtilsTest {
     }
 
     @Test
+    public void testChopNewlineEmptyString() {
+        assertEquals("", StringUtils.chopNewline(""));
+    }
+
+    @Test
     public void testClean() {
         assertEquals("", StringUtils.clean(null));
 


### PR DESCRIPTION
`StringUtils.chopNewline("")` throws `StringIndexOutOfBoundsException` because `lastIdx = str.length() - 1` evaluates to `-1` when `str` is empty, then `str.charAt(lastIdx)` reads at index `-1`.

Added an empty-string guard before computing `lastIdx`, consistent with the guard already used by `chop()`.

Fixes https://github.com/apache/maven-shared-utils/issues/379