### PR TITLE
PrettyPrintXMLWriter: handle null lineIndent in constructors

### DIFF
--- a/src/main/java/org/apache/maven/shared/utils/xml/PrettyPrintXMLWriter.java
+++ b/src/main/java/org/apache/maven/shared/utils/xml/PrettyPrintXMLWriter.java
@@ -95,7 +95,12 @@ public class PrettyPrintXMLWriter implements XMLWriter {
      * @param doctype can be null
      */
     public PrettyPrintXMLWriter(PrintWriter writer, String lineIndent, String encoding, String doctype) {
-        this(writer, lineIndent.toCharArray(), "\n".toCharArray(), encoding, doctype);
+        this(
+                writer,
+                lineIndent != null ? lineIndent.toCharArray() : DEFAULT_LINE_INDENT,
+                "\n".toCharArray(),
+                encoding,
+                doctype);
     }
 
     /**
@@ -135,7 +140,12 @@ public class PrettyPrintXMLWriter implements XMLWriter {
      */
     public PrettyPrintXMLWriter(
             PrintWriter writer, String lineIndent, String lineSeparator, String encoding, String doctype) {
-        this(writer, lineIndent.toCharArray(), lineSeparator.toCharArray(), encoding, doctype);
+        this(
+                writer,
+                lineIndent != null ? lineIndent.toCharArray() : DEFAULT_LINE_INDENT,
+                lineSeparator != null ? lineSeparator.toCharArray() : "\n".toCharArray(),
+                encoding,
+                doctype);
     }
 
     /**

--- a/src/test/java/org/apache/maven/shared/utils/xml/PrettyPrintXmlWriterTest.java
+++ b/src/test/java/org/apache/maven/shared/utils/xml/PrettyPrintXmlWriterTest.java
@@ -95,9 +95,15 @@ public class PrettyPrintXmlWriterTest {
 
     @Test
     public void testPrettyPrintXMLWriterWithNullLineIndent() throws IOException {
-        PrettyPrintXMLWriter writer = new PrettyPrintXMLWriter(new StringWriter(), (String) null);
-        writer.startElement("div");
-        writer.endElement();
+        StringWriter sw = new StringWriter();
+        PrettyPrintXMLWriter writer = new PrettyPrintXMLWriter(sw, (String) null);
+
+        writer.startElement(HTML.Tag.HTML.toString());
+        writeXhtmlHead(writer);
+        writeXhtmlBody(writer);
+        writer.endElement(); // Tag.HTML
+
+        assertEquals(expectedResult(), sw.toString());
     }
 
     @Test

--- a/src/test/java/org/apache/maven/shared/utils/xml/PrettyPrintXmlWriterTest.java
+++ b/src/test/java/org/apache/maven/shared/utils/xml/PrettyPrintXmlWriterTest.java
@@ -94,6 +94,13 @@ public class PrettyPrintXmlWriterTest {
     }
 
     @Test
+    public void testPrettyPrintXMLWriterWithNullLineIndent() throws IOException {
+        PrettyPrintXMLWriter writer = new PrettyPrintXMLWriter(new StringWriter(), (String) null);
+        writer.startElement("div");
+        writer.endElement();
+    }
+
+    @Test
     public void testEscapeXmlAttributeWindows() throws IOException {
         // Windows
         writer.startElement(HTML.Tag.DIV.toString());


### PR DESCRIPTION
Constructors accepting a `String lineIndent` parameter document it "can be null" but call `lineIndent.toCharArray()` without a null check, throwing `NullPointerException`.

Fixed constructors now fall back to the default indentation (two spaces) when `lineIndent` is null, and to `"\n"` when `lineSeparator` is null — matching the behavior of the constructors that don't take these parameters.

Fixes https://github.com/apache/maven-shared-utils/issues/381

Commits:
- 581ca4a — Add failing test: PrettyPrintXMLWriter with null lineIndent
- b38df77 — PrettyPrintXMLWriter: handle null lineIndent/lineSeparator in constructors