### PR TITLE
PathTool.getRelativeFilePath: fix broken Windows drive-letter regex

### DIFF
--- a/src/main/java/org/apache/maven/shared/utils/PathTool.java
+++ b/src/main/java/org/apache/maven/shared/utils/PathTool.java
@@ -143,10 +143,12 @@ public class PathTool {
         String toPath = new File(newPath).getPath();
 
         // strip any leading slashes if its a windows path
-        if (toPath.matches("^\\[a-zA-Z]:")) {
+        if (toPath.length() > 2 && toPath.charAt(0) == '\\'
+                && Character.isLetter(toPath.charAt(1)) && toPath.charAt(2) == ':') {
             toPath = toPath.substring(1);
         }
-        if (fromPath.matches("^\\[a-zA-Z]:")) {
+        if (fromPath.length() > 2 && fromPath.charAt(0) == '\\'
+                && Character.isLetter(fromPath.charAt(1)) && fromPath.charAt(2) == ':') {
             fromPath = fromPath.substring(1);
         }
 

--- a/src/main/java/org/apache/maven/shared/utils/PathTool.java
+++ b/src/main/java/org/apache/maven/shared/utils/PathTool.java
@@ -142,7 +142,7 @@ public class PathTool {
         String fromPath = new File(oldPath).getPath();
         String toPath = new File(newPath).getPath();
 
-        // strip any leading slashes if its a windows path
+        // strip any leading backslash before a Windows drive letter
         if (toPath.length() > 2
                 && toPath.charAt(0) == '\\'
                 && Character.isLetter(toPath.charAt(1))

--- a/src/main/java/org/apache/maven/shared/utils/PathTool.java
+++ b/src/main/java/org/apache/maven/shared/utils/PathTool.java
@@ -143,12 +143,16 @@ public class PathTool {
         String toPath = new File(newPath).getPath();
 
         // strip any leading slashes if its a windows path
-        if (toPath.length() > 2 && toPath.charAt(0) == '\\'
-                && Character.isLetter(toPath.charAt(1)) && toPath.charAt(2) == ':') {
+        if (toPath.length() > 2
+                && toPath.charAt(0) == '\\'
+                && Character.isLetter(toPath.charAt(1))
+                && toPath.charAt(2) == ':') {
             toPath = toPath.substring(1);
         }
-        if (fromPath.length() > 2 && fromPath.charAt(0) == '\\'
-                && Character.isLetter(fromPath.charAt(1)) && fromPath.charAt(2) == ':') {
+        if (fromPath.length() > 2
+                && fromPath.charAt(0) == '\\'
+                && Character.isLetter(fromPath.charAt(1))
+                && fromPath.charAt(2) == ':') {
             fromPath = fromPath.substring(1);
         }
 

--- a/src/test/java/org/apache/maven/shared/utils/PathToolTest.java
+++ b/src/test/java/org/apache/maven/shared/utils/PathToolTest.java
@@ -103,6 +103,15 @@ public class PathToolTest {
     }
 
     @Test
+    public void testGetRelativeFilePathWithDifferentWindowsDrives() {
+        // Tests that the regex fix at line 146 correctly strips a leading backslash
+        // before a Windows drive letter. The old regex "^\\[a-zA-Z]:" matched the
+        // literal string "[a-zA-Z]:" instead of a backslash + drive letter.
+        // Different drives with leading backslash should return null.
+        assertNull(PathTool.getRelativeFilePath("\\C:\\usr\\local", "\\D:\\usr\\local\\java\\bin"));
+    }
+
+    @Test
     public void testUppercaseDrive() {
         assertNull(PathTool.uppercaseDrive(null));
 

--- a/src/test/java/org/apache/maven/shared/utils/PathToolTest.java
+++ b/src/test/java/org/apache/maven/shared/utils/PathToolTest.java
@@ -104,10 +104,9 @@ public class PathToolTest {
 
     @Test
     public void testGetRelativeFilePathWithDifferentWindowsDrives() {
-        // Tests that the regex fix at line 146 correctly strips a leading backslash
-        // before a Windows drive letter. The old regex "^\\[a-zA-Z]:" matched the
-        // literal string "[a-zA-Z]:" instead of a backslash + drive letter.
-        // Different drives with leading backslash should return null.
+        // Verifies that a leading backslash before a Windows drive letter (e.g. "\C:\\...")
+        // is stripped so the drive-letter comparison logic runs.
+        // Different drives should return null.
         assertNull(PathTool.getRelativeFilePath("\\C:\\usr\\local", "\\D:\\usr\\local\\java\\bin"));
     }
 


### PR DESCRIPTION
The regex `^\\[a-zA-Z]:` at lines 146 and 149 had two bugs:

1. The `\\[` matched a literal `[` character, not a backslash, because `[` was escaped by `\`
2. `String.matches()` requires the *entire* string to match the pattern, but this regex was intended to match only the leading `\C:` prefix — so it never matched any real path

The Windows drive-letter normalization code was effectively dead. Paths like `\C:\foo` (produced by `File.getPath()` on Windows) were never getting their leading `\` stripped, causing the drive-letter comparison logic at lines 154–175 to be skipped. This could produce incorrect relative paths or fail to detect mismatched drives (returning a path instead of `null`).

**Fix:** Replaced the broken regex with a simple character-level check:
```java
if (toPath.length() > 2 && toPath.charAt(0) == '\\'
        && Character.isLetter(toPath.charAt(1)) && toPath.charAt(2) == ':')
```

Fixes https://github.com/apache/maven-shared-utils/issues/383