### PR TITLE
StreamPollFeeder: declare done and exception as volatile

### DIFF
--- a/src/main/java/org/apache/maven/shared/utils/cli/StreamPollFeeder.java
+++ b/src/main/java/org/apache/maven/shared/utils/cli/StreamPollFeeder.java
@@ -35,9 +35,9 @@ class StreamPollFeeder extends Thread {
     private final InputStream input;
     private final OutputStream output;
 
-    private Throwable exception;
+    private volatile Throwable exception;
 
-    private boolean done;
+    private volatile boolean done;
     private final Object lock = new Object();
 
     /**

--- a/src/test/java/org/apache/maven/shared/utils/cli/StreamPollFeederTest.java
+++ b/src/test/java/org/apache/maven/shared/utils/cli/StreamPollFeederTest.java
@@ -49,14 +49,12 @@ public class StreamPollFeederTest {
             }
         };
 
-        assertTimeoutPreemptively(
-                Duration.ofSeconds(5),
-                () -> {
-                    StreamPollFeeder feeder = new StreamPollFeeder(continuousInput, new ByteArrayOutputStream());
-                    feeder.start();
-                    feeder.waitUntilDone();
-                    assertNull(feeder.getException());
-                });
+        assertTimeoutPreemptively(Duration.ofSeconds(5), () -> {
+            StreamPollFeeder feeder = new StreamPollFeeder(continuousInput, new ByteArrayOutputStream());
+            feeder.start();
+            feeder.waitUntilDone();
+            assertNull(feeder.getException());
+        });
     }
 
     @Test

--- a/src/test/java/org/apache/maven/shared/utils/cli/StreamPollFeederTest.java
+++ b/src/test/java/org/apache/maven/shared/utils/cli/StreamPollFeederTest.java
@@ -22,6 +22,7 @@ import java.io.ByteArrayInputStream;
 import java.io.ByteArrayOutputStream;
 import java.io.IOException;
 import java.io.InputStream;
+import java.io.OutputStream;
 import java.time.Duration;
 
 import org.junit.jupiter.api.Test;
@@ -50,7 +51,7 @@ public class StreamPollFeederTest {
         };
 
         assertTimeoutPreemptively(Duration.ofSeconds(5), () -> {
-            StreamPollFeeder feeder = new StreamPollFeeder(continuousInput, new java.io.OutputStream() {
+            StreamPollFeeder feeder = new StreamPollFeeder(continuousInput, new OutputStream() {
                 @Override
                 public void write(int b) {
                     // discard

--- a/src/test/java/org/apache/maven/shared/utils/cli/StreamPollFeederTest.java
+++ b/src/test/java/org/apache/maven/shared/utils/cli/StreamPollFeederTest.java
@@ -20,13 +20,44 @@ package org.apache.maven.shared.utils.cli;
 
 import java.io.ByteArrayInputStream;
 import java.io.ByteArrayOutputStream;
+import java.io.IOException;
+import java.io.InputStream;
+import java.time.Duration;
 
 import org.junit.jupiter.api.Test;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertTimeoutPreemptively;
 
 public class StreamPollFeederTest {
+
+    @Test
+    public void waitUntilFeederDoneWithContinuousData() {
+        // Simulates a stream with continuous data where the feeder thread
+        // never enters the synchronized(lock) wait block, so the done
+        // flag must be visible without relying on lock's happens-before.
+        InputStream continuousInput = new InputStream() {
+            @Override
+            public int available() {
+                return 1;
+            }
+
+            @Override
+            public int read() throws IOException {
+                return 0;
+            }
+        };
+
+        assertTimeoutPreemptively(
+                Duration.ofSeconds(5),
+                () -> {
+                    StreamPollFeeder feeder = new StreamPollFeeder(continuousInput, new ByteArrayOutputStream());
+                    feeder.start();
+                    feeder.waitUntilDone();
+                    assertNull(feeder.getException());
+                });
+    }
 
     @Test
     public void waitUntilFeederDoneOnInputStream() throws Exception {

--- a/src/test/java/org/apache/maven/shared/utils/cli/StreamPollFeederTest.java
+++ b/src/test/java/org/apache/maven/shared/utils/cli/StreamPollFeederTest.java
@@ -50,7 +50,13 @@ public class StreamPollFeederTest {
         };
 
         assertTimeoutPreemptively(Duration.ofSeconds(5), () -> {
-            StreamPollFeeder feeder = new StreamPollFeeder(continuousInput, new ByteArrayOutputStream());
+            StreamPollFeeder feeder = new StreamPollFeeder(continuousInput, new java.io.OutputStream() {
+                @Override
+                public void write(int b) {
+                    // discard
+                }
+            });
+            feeder.setDaemon(true);
             feeder.start();
             feeder.waitUntilDone();
             assertNull(feeder.getException());


### PR DESCRIPTION
`StreamPollFeeder.done` and `StreamPollFeeder.exception` are accessed from multiple threads without `volatile`, violating the Java Memory Model.

**`done`** (line 40): read in `run()` outside any `synchronized` block (line 61), written in `waitUntilDone()` inside `synchronized (lock)` (line 107). When the feeder thread is continuously reading data (`input.available() > 0`), it never enters the `synchronized` block, so no happens‑before guarantees the write to `done` is ever seen. The thread loops forever and `waitUntilDone()`'s `join()` call hangs.

**`exception`** (line 38): written by the `run()` thread (lines 79, 92) and read from other threads via `getException()` (line 101). Without `volatile`, a thread calling `getException()` may see a stale `null`. `StreamPumper` already declares its equivalent field as `volatile` — `StreamPollFeeder` should follow the same pattern.

Fixes https://github.com/apache/maven-shared-utils/issues/385
Fixes https://github.com/apache/maven-shared-utils/issues/386