### PR TITLE
Xpp3Dom.getValue(): honor @NonNull contract

### DIFF
--- a/src/main/java/org/apache/maven/shared/utils/xml/Xpp3Dom.java
+++ b/src/main/java/org/apache/maven/shared/utils/xml/Xpp3Dom.java
@@ -95,6 +95,10 @@ public class Xpp3Dom implements Iterable<Xpp3Dom> {
         childMap = new HashMap<>();
     }
 
+    boolean isValueSet() {
+        return value != null;
+    }
+
     /**
      * Create instance.
      *
@@ -140,7 +144,7 @@ public class Xpp3Dom implements Iterable<Xpp3Dom> {
      */
     @NonNull
     public String getValue() {
-        return value;
+        return value != null ? value : "";
     }
 
     /**

--- a/src/main/java/org/apache/maven/shared/utils/xml/Xpp3DomWriter.java
+++ b/src/main/java/org/apache/maven/shared/utils/xml/Xpp3DomWriter.java
@@ -72,8 +72,8 @@ public class Xpp3DomWriter {
             write(xmlWriter, aChildren, escape);
         }
 
-        String value = dom.getValue();
-        if (value != null) {
+        if (dom.isValueSet()) {
+            String value = dom.getValue();
             if (escape) {
                 xmlWriter.writeText(value);
             } else {

--- a/src/test/java/org/apache/maven/shared/utils/xml/pull/Xpp3DomTest.java
+++ b/src/test/java/org/apache/maven/shared/utils/xml/pull/Xpp3DomTest.java
@@ -28,7 +28,6 @@ import static org.apache.maven.shared.utils.xml.Xpp3Dom.mergeXpp3Dom;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNotEquals;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
-import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 
 /**

--- a/src/test/java/org/apache/maven/shared/utils/xml/pull/Xpp3DomTest.java
+++ b/src/test/java/org/apache/maven/shared/utils/xml/pull/Xpp3DomTest.java
@@ -90,7 +90,7 @@ public class Xpp3DomTest {
         Xpp3Dom result = mergeXpp3Dom(t1, t2);
 
         assertEquals(2, result.getAttributeNames().length);
-        assertNull(result.getValue());
+        assertEquals("", result.getValue());
     }
 
     @Test

--- a/src/test/java/org/apache/maven/shared/utils/xml/pull/Xpp3DomTest.java
+++ b/src/test/java/org/apache/maven/shared/utils/xml/pull/Xpp3DomTest.java
@@ -27,6 +27,7 @@ import org.junit.jupiter.api.Test;
 import static org.apache.maven.shared.utils.xml.Xpp3Dom.mergeXpp3Dom;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNotEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 
@@ -40,6 +41,13 @@ public class Xpp3DomTest {
         Xpp3Dom t1s1 = new Xpp3Dom(element);
         t1s1.setValue(value);
         return t1s1;
+    }
+
+    @Test
+    public void defaultValueIsNotNull() {
+        // getValue() is annotated @NonNull but the one-arg constructor
+        // did not initialize value, violating the contract.
+        assertNotNull(new Xpp3Dom("test").getValue());
     }
 
     @Test


### PR DESCRIPTION
`Xpp3Dom.getValue()` is annotated `@NonNull` (line 141) but can return `null` when the instance was created via `new Xpp3Dom(name)` (the `value` field is never initialized in the one-arg constructor).

**Fix:**
- `getValue()` now returns `""` when the internal `value` field is null, upholding the `@NonNull` contract
- Added package-private `isValueSet()` method so `Xpp3DomWriter` can distinguish between "value was explicitly set to empty string" and "value was never set" — preserving the existing serialization behavior (elements with unset values serialize as self-closing tags)

The builder at `Xpp3DomBuilder.java:201` already worked around this with `element.setValue(""); // null in xpp3dom, but we don't do that around here`.

Fixes https://github.com/apache/maven-shared-utils/issues/388