### PR TITLE
XMLEncode: encode illegal XML control characters

### DIFF
--- a/src/main/java/org/apache/maven/shared/utils/xml/XMLEncode.java
+++ b/src/main/java/org/apache/maven/shared/utils/xml/XMLEncode.java
@@ -109,7 +109,13 @@ final class XMLEncode {
                     break;
 
                 default:
-                    n.append(c);
+                    if (c < 0x20 && c != 0x09 && c != 0x0A && c != 0x0D) {
+                        n.append("&#x");
+                        n.append(Integer.toHexString(c));
+                        n.append(';');
+                    } else {
+                        n.append(c);
+                    }
                     break;
             }
         }
@@ -143,6 +149,9 @@ final class XMLEncode {
         for (int i = 0; i < text.length(); i++) {
             char c = text.charAt(i);
             if (c == '&' || c == '<') {
+                return true;
+            }
+            if (c < 0x20 && c != 0x09 && c != 0x0A && c != 0x0D) {
                 return true;
             }
         }

--- a/src/main/java/org/apache/maven/shared/utils/xml/XMLEncode.java
+++ b/src/main/java/org/apache/maven/shared/utils/xml/XMLEncode.java
@@ -109,6 +109,12 @@ final class XMLEncode {
                     break;
 
                 default:
+                    // C0 control characters (except tab, LF, CR) are encoded
+                    // as numeric character references. This produces valid
+                    // XML 1.1 but is not valid XML 1.0 (which forbids these
+                    // characters in any form). Callers that require strict
+                    // XML 1.0 compliance should strip these characters before
+                    // encoding.
                     if (c < 0x20 && c != 0x09 && c != 0x0A && c != 0x0D) {
                         n.append("&#x");
                         n.append(Integer.toHexString(c));
@@ -141,6 +147,12 @@ final class XMLEncode {
 
     /**
      * Checks if this text needs encoding in order to be represented in XML.
+     * Note: C0 control characters (U+0000-U+001F except tab, LF, CR) are
+     * classified as needing encoding, but encoding them as numeric character
+     * references produces output that is not valid XML 1.0 (which forbids
+     * these characters outright in any form). The encoded output is valid
+     * XML 1.1. Callers that require strict XML 1.0 compliance should strip
+     * these characters before encoding.
      */
     private static boolean needsEncoding(String text) {
         if (text == null) {

--- a/src/main/java/org/apache/maven/shared/utils/xml/XMLEncode.java
+++ b/src/main/java/org/apache/maven/shared/utils/xml/XMLEncode.java
@@ -41,7 +41,7 @@ final class XMLEncode {
             writer.write(text);
             return;
         } else {
-            // only encode as cdata if is is longer than CDATA block overhead:
+            // only encode as cdata if it is longer than CDATA block overhead:
             if (text.length() > CDATA_BLOCK_THRESHOLD_LENGTH) {
                 String cdata = xmlEncodeTextAsCDATABlock(text);
                 if (cdata != null) {
@@ -51,7 +51,7 @@ final class XMLEncode {
             }
         }
 
-        // if every thing else fails, do it the save way...
+        // if everything else fails, do it the save way...
         xmlEncodeTextAsPCDATA(text, false, DEFAULT_QUOTE_CHAR, writer);
     }
 
@@ -109,16 +109,10 @@ final class XMLEncode {
                     break;
 
                 default:
-                    // C0 control characters (except tab, LF, CR) are encoded
-                    // as numeric character references. This produces valid
-                    // XML 1.1 but is not valid XML 1.0 (which forbids these
-                    // characters in any form). Callers that require strict
-                    // XML 1.0 compliance should strip these characters before
-                    // encoding.
+                    // C0 control characters (except tab, LF, CR) are forbidden in XML 1.0.
+                    // Callers should strip these characters before encoding.
                     if (c < 0x20 && c != 0x09 && c != 0x0A && c != 0x0D) {
-                        n.append("&#x");
-                        n.append(Integer.toHexString(c));
-                        n.append(';');
+                        throw new IOException("C0 controls are not allowed in XML text");
                     } else {
                         n.append(c);
                     }

--- a/src/test/java/org/apache/maven/shared/utils/xml/PrettyPrintXmlWriterTest.java
+++ b/src/test/java/org/apache/maven/shared/utils/xml/PrettyPrintXmlWriterTest.java
@@ -94,6 +94,26 @@ public class PrettyPrintXmlWriterTest {
     }
 
     @Test
+    public void testEncodeIllegalControlCharsInText() throws IOException {
+        StringWriter sw = new StringWriter();
+        PrettyPrintXMLWriter w = new PrettyPrintXMLWriter(sw);
+        w.startElement("div");
+        w.writeText("hello\u0001world");
+        w.endElement();
+        assertEquals("<div>hello&#x1;world</div>", sw.toString());
+    }
+
+    @Test
+    public void testEncodeIllegalControlCharsInAttribute() throws IOException {
+        StringWriter sw = new StringWriter();
+        PrettyPrintXMLWriter w = new PrettyPrintXMLWriter(sw);
+        w.startElement("div");
+        w.addAttribute("title", "hello\u0001world");
+        w.endElement();
+        assertEquals("<div title=\"hello&#x1;world\"/>", sw.toString());
+    }
+
+    @Test
     public void testEscapeXmlAttributeWindows() throws IOException {
         // Windows
         writer.startElement(HTML.Tag.DIV.toString());

--- a/src/test/java/org/apache/maven/shared/utils/xml/PrettyPrintXmlWriterTest.java
+++ b/src/test/java/org/apache/maven/shared/utils/xml/PrettyPrintXmlWriterTest.java
@@ -94,6 +94,26 @@ public class PrettyPrintXmlWriterTest {
     }
 
     @Test
+    public void testEncodeIllegalControlCharsInText() throws IOException {
+        StringWriter sw = new StringWriter();
+        PrettyPrintXMLWriter w = new PrettyPrintXMLWriter(sw);
+        w.startElement("div");
+        w.writeText("hello\u0001world");
+        w.endElement();
+        assertEquals("<div>hello&#x1;world</div>", sw.toString());
+    }
+
+    @Test
+    public void testEncodeIllegalControlCharsInAttribute() throws IOException {
+        StringWriter sw = new StringWriter();
+        PrettyPrintXMLWriter w = new PrettyPrintXMLWriter(sw);
+        w.startElement("div");
+        w.addAttribute("title", "hello\u0001world");
+        w.endElement();
+        assertEquals("<div title=\"hello&#x1;world\"/>", sw.toString());
+    }
+
+    @Test
     public void testPrettyPrintXMLWriterWithNullLineIndent() throws IOException {
         StringWriter sw = new StringWriter();
         PrettyPrintXMLWriter writer = new PrettyPrintXMLWriter(sw, (String) null);

--- a/src/test/java/org/apache/maven/shared/utils/xml/PrettyPrintXmlWriterTest.java
+++ b/src/test/java/org/apache/maven/shared/utils/xml/PrettyPrintXmlWriterTest.java
@@ -27,6 +27,7 @@ import org.apache.maven.shared.utils.StringUtils;
 import org.junit.jupiter.api.Test;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.fail;
 
 /**
@@ -98,9 +99,12 @@ public class PrettyPrintXmlWriterTest {
         StringWriter sw = new StringWriter();
         PrettyPrintXMLWriter w = new PrettyPrintXMLWriter(sw);
         w.startElement("div");
-        w.writeText("hello\u0001world");
-        w.endElement();
-        assertEquals("<div>hello&#x1;world</div>", sw.toString());
+        try {
+            w.writeText("hello\u0001world");
+            fail();
+        } catch (IOException expected) {
+            assertNotNull(expected.getMessage());
+        }
     }
 
     @Test
@@ -108,9 +112,12 @@ public class PrettyPrintXmlWriterTest {
         StringWriter sw = new StringWriter();
         PrettyPrintXMLWriter w = new PrettyPrintXMLWriter(sw);
         w.startElement("div");
-        w.addAttribute("title", "hello\u0001world");
-        w.endElement();
-        assertEquals("<div title=\"hello&#x1;world\"/>", sw.toString());
+        try {
+            w.addAttribute("title", "hello\u0001world");
+            fail();
+        } catch (IOException expected) {
+            assertNotNull(expected.getMessage());
+        }
     }
 
     @Test


### PR DESCRIPTION
`XMLEncode.xmlEncodeTextAsPCDATA()` passes characters in the range U+0000–U+001F (excluding TAB, LF, CR) through unencoded in the `default` branch of its switch statement. These characters are illegal in XML 1.0 and cause XML parsers to reject the output.

Additionally, `needsEncoding()` only checked for `&` and `<`, so text containing only control characters was written directly without reaching the encoding method at all.

**Fix:**
- Throw IOException for completely illegal characters that cannot appear in XML 
- In `needsEncoding()`, added a check for illegal control chars so they're routed through the encoding path

Fixes https://github.com/apache/maven-shared-utils/issues/390