### PR TITLE
Xpp3Dom.removeChild(int): fix childMap corruption with duplicate names

### DIFF
--- a/src/main/java/org/apache/maven/shared/utils/xml/Xpp3Dom.java
+++ b/src/main/java/org/apache/maven/shared/utils/xml/Xpp3Dom.java
@@ -261,8 +261,22 @@ public class Xpp3Dom implements Iterable<Xpp3Dom> {
      */
     public void removeChild(int i) {
         Xpp3Dom child = childList.remove(i);
-        childMap.values().remove(child);
         child.setParent(null);
+
+        String name = child.getName();
+        if (childMap.get(name) == child) {
+            Xpp3Dom lastWithName = null;
+            for (Xpp3Dom c : childList) {
+                if (name.equals(c.getName())) {
+                    lastWithName = c;
+                }
+            }
+            if (lastWithName != null) {
+                childMap.put(name, lastWithName);
+            } else {
+                childMap.remove(name);
+            }
+        }
     }
 
     /**

--- a/src/main/java/org/apache/maven/shared/utils/xml/Xpp3Dom.java
+++ b/src/main/java/org/apache/maven/shared/utils/xml/Xpp3Dom.java
@@ -265,8 +265,22 @@ public class Xpp3Dom implements Iterable<Xpp3Dom> {
      */
     public void removeChild(int i) {
         Xpp3Dom child = childList.remove(i);
-        childMap.values().remove(child);
         child.setParent(null);
+
+        String name = child.getName();
+        if (childMap.get(name) == child) {
+            Xpp3Dom lastWithName = null;
+            for (Xpp3Dom c : childList) {
+                if (name.equals(c.getName())) {
+                    lastWithName = c;
+                }
+            }
+            if (lastWithName != null) {
+                childMap.put(name, lastWithName);
+            } else {
+                childMap.remove(name);
+            }
+        }
     }
 
     /**

--- a/src/test/java/org/apache/maven/shared/utils/xml/pull/Xpp3DomTest.java
+++ b/src/test/java/org/apache/maven/shared/utils/xml/pull/Xpp3DomTest.java
@@ -56,8 +56,9 @@ public class Xpp3DomTest {
 
         assertEquals(1, parent.getChildCount());
         assertEquals("first", parent.getChild("child").getValue());
-    }   
-     
+    }
+
+
     @Test
     public void defaultValueIsNotNull() {
         // getValue() is annotated @NonNull but the one-arg constructor

--- a/src/test/java/org/apache/maven/shared/utils/xml/pull/Xpp3DomTest.java
+++ b/src/test/java/org/apache/maven/shared/utils/xml/pull/Xpp3DomTest.java
@@ -43,6 +43,22 @@ public class Xpp3DomTest {
     }
 
     @Test
+    public void removeChildByIndexUpdatesChildMap() {
+        Xpp3Dom parent = new Xpp3Dom("parent");
+        Xpp3Dom first = new Xpp3Dom("child");
+        first.setValue("first");
+        Xpp3Dom second = new Xpp3Dom("child");
+        second.setValue("second");
+        parent.addChild(first);
+        parent.addChild(second);
+
+        parent.removeChild(1);
+
+        assertEquals(1, parent.getChildCount());
+        assertEquals("first", parent.getChild("child").getValue());
+    }
+
+    @Test
     public void mergePrecedenceSelfClosed() throws XmlPullParserException {
         Xpp3Dom parentConfig = build("<configuration><items><item/></items></configuration>");
         Xpp3Dom childConfig = build("<configuration><items><item>ooopise</item></items></configuration>");

--- a/src/test/java/org/apache/maven/shared/utils/xml/pull/Xpp3DomTest.java
+++ b/src/test/java/org/apache/maven/shared/utils/xml/pull/Xpp3DomTest.java
@@ -58,7 +58,6 @@ public class Xpp3DomTest {
         assertEquals("first", parent.getChild("child").getValue());
     }
 
-
     @Test
     public void defaultValueIsNotNull() {
         // getValue() is annotated @NonNull but the one-arg constructor

--- a/src/test/java/org/apache/maven/shared/utils/xml/pull/Xpp3DomTest.java
+++ b/src/test/java/org/apache/maven/shared/utils/xml/pull/Xpp3DomTest.java
@@ -50,6 +50,22 @@ public class Xpp3DomTest {
     }
 
     @Test
+    public void removeChildByIndexUpdatesChildMap() {
+        Xpp3Dom parent = new Xpp3Dom("parent");
+        Xpp3Dom first = new Xpp3Dom("child");
+        first.setValue("first");
+        Xpp3Dom second = new Xpp3Dom("child");
+        second.setValue("second");
+        parent.addChild(first);
+        parent.addChild(second);
+
+        parent.removeChild(1);
+
+        assertEquals(1, parent.getChildCount());
+        assertEquals("first", parent.getChild("child").getValue());
+    }
+
+    @Test
     public void mergePrecedenceSelfClosed() throws XmlPullParserException {
         Xpp3Dom parentConfig = build("<configuration><items><item/></items></configuration>");
         Xpp3Dom childConfig = build("<configuration><items><item>ooopise</item></items></configuration>");


### PR DESCRIPTION
`Xpp3Dom.removeChild(int)` (line 262) calls `childMap.values().remove(child)` to remove the child from the internal name-to-child map. This is incorrect when multiple children share the same name:

- `childMap` stores only the *last* child added with a given name (entries are overwritten by `addChild`)
- `values().remove(child)` removes the first matching value — which is the *only* value for that name in the map
- When removing a child that was overwritten in the map (i.e., a later child with the same name was added), the map entry is left pointing to the wrong child
- When removing the last child with that name, `getChild(name)` correctly returns null but only by coincidence — the map entry was simply removed

**Fix:** After removing the child from `childList`, check if `childMap` points to that specific child (by reference). If so, scan `childList` for the last remaining child with the same name and update the map, or remove the entry if none remain.

Fixes https://github.com/apache/maven-shared-utils/issues/394