### PR TITLE
Xpp3DomWriter: add explicit null check for dom parameter

### DIFF
--- a/src/main/java/org/apache/maven/shared/utils/xml/Xpp3DomWriter.java
+++ b/src/main/java/org/apache/maven/shared/utils/xml/Xpp3DomWriter.java
@@ -21,6 +21,7 @@ package org.apache.maven.shared.utils.xml;
 import java.io.IOException;
 import java.io.PrintWriter;
 import java.io.Writer;
+import java.util.Objects;
 
 /**
  * @author Brett Porter
@@ -62,6 +63,7 @@ public class Xpp3DomWriter {
      * @throws IOException if writing fails
      */
     public static void write(XMLWriter xmlWriter, Xpp3Dom dom, boolean escape) throws IOException {
+        Objects.requireNonNull(dom, "dom must not be null");
         xmlWriter.startElement(dom.getName());
         String[] attributeNames = dom.getAttributeNames();
         for (String attributeName : attributeNames) {

--- a/src/test/java/org/apache/maven/shared/utils/xml/Xpp3DomWriterTest.java
+++ b/src/test/java/org/apache/maven/shared/utils/xml/Xpp3DomWriterTest.java
@@ -1,0 +1,32 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.maven.shared.utils.xml;
+
+import java.io.StringWriter;
+
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.assertThrows;
+
+class Xpp3DomWriterTest {
+    @Test
+    void writeNullDom() {
+        assertThrows(NullPointerException.class, () -> Xpp3DomWriter.write(new StringWriter(), null));
+    }
+}


### PR DESCRIPTION
All public `write` methods accept an `Xpp3Dom dom` parameter without null checks. Passing `null` throws a `NullPointerException` deep inside the delegation chain (at `dom.getName()` in the `write(XMLWriter, Xpp3Dom, boolean)` method), producing a confusing stack trace for callers.

**Fix:** Added `Objects.requireNonNull(dom, "dom must not be null")` at the entry to the shared `write(XMLWriter, Xpp3Dom, boolean)` method, so callers get a clear message immediately.

Fixes https://github.com/apache/maven-shared-utils/issues/396