### PR TITLE
CommandLineUtils: ensure all pumpers are waited on in try-finally

### DIFF
--- a/src/main/java/org/apache/maven/shared/utils/cli/CommandLineUtils.java
+++ b/src/main/java/org/apache/maven/shared/utils/cli/CommandLineUtils.java
@@ -274,33 +274,17 @@ public abstract class CommandLineUtils {
 
                     int returnValue = p.waitFor();
 
-                    // TODO Find out if waitUntilDone needs to be called using a try-finally construct. The method may
-                    // throw an
-                    //      InterruptedException so that calls to waitUntilDone may be skipped.
-                    //                    try
-                    //                    {
-                    //                        if ( inputFeeder != null )
-                    //                        {
-                    //                            inputFeeder.waitUntilDone();
-                    //                        }
-                    //                    }
-                    //                    finally
-                    //                    {
-                    //                        try
-                    //                        {
-                    //                            outputPumper.waitUntilDone();
-                    //                        }
-                    //                        finally
-                    //                        {
-                    //                            errorPumper.waitUntilDone();
-                    //                        }
-                    //                    }
-                    if (inputFeeder != null) {
-                        inputFeeder.waitUntilDone();
+                    try {
+                        if (inputFeeder != null) {
+                            inputFeeder.waitUntilDone();
+                        }
+                    } finally {
+                        try {
+                            outputPumper.waitUntilDone();
+                        } finally {
+                            errorPumper.waitUntilDone();
+                        }
                     }
-
-                    outputPumper.waitUntilDone();
-                    errorPumper.waitUntilDone();
 
                     if (inputFeeder != null && inputFeeder.getException() != null) {
                         throw new CommandLineException("Failure processing stdin.", inputFeeder.getException());


### PR DESCRIPTION
In `CommandLineUtils.call()`, `waitUntilDone()` was called on `inputFeeder`, `outputPumper`, and `errorPumper` sequentially without try-finally (lines 298-303 of the original). If an earlier call threw (e.g., `InterruptedException`), the remaining pumpers were never waited on, leaving their threads potentially running.

The commented-out code just above (lines 277-297) shows the original author intended a try-finally chain but never enabled it.

**Fix:** Replaced the sequential calls and the dead commented block with a proper try-finally chain ensuring all three pumpers are waited on regardless of exceptions from earlier ones.

Fixes https://github.com/apache/maven-shared-utils/issues/398