### PR TITLE
StringUtils.chompLast: fix StringIndexOutOfBoundsException when sep longer than str

### DIFF
--- a/src/main/java/org/apache/maven/shared/utils/StringUtils.java
+++ b/src/main/java/org/apache/maven/shared/utils/StringUtils.java
@@ -851,7 +851,7 @@ public class StringUtils {
      */
     @NonNull
     public static String chompLast(@NonNull String str, @NonNull String sep) {
-        if (str.length() == 0) {
+        if (str.length() == 0 || sep.length() > str.length()) {
             return str;
         }
         String sub = str.substring(str.length() - sep.length());

--- a/src/test/java/org/apache/maven/shared/utils/StringUtilsTest.java
+++ b/src/test/java/org/apache/maven/shared/utils/StringUtilsTest.java
@@ -215,6 +215,11 @@ public class StringUtilsTest {
     }
 
     @Test
+    public void testChompLastSepLongerThanStr() {
+        assertEquals("x", StringUtils.chompLast("x", "ab"));
+    }
+
+    @Test
     public void testChopNPE() {
         assertThrows(NullPointerException.class, () -> StringUtils.chop(null));
     }


### PR DESCRIPTION
StringUtils.chompLast(String str, String sep) at line 857 computes `str.substring(str.length() - sep.length())` without checking whether sep is longer than str. When sep.length() > str.length(), the start index is negative, throwing StringIndexOutOfBoundsException.

**Fix:** Added `|| sep.length() > str.length()` to the existing guard, returning str unchanged when the separator is longer than the string (since it can't possibly end with that separator).

Fixes https://github.com/apache/maven-shared-utils/issues/400