### PR TITLE
PathTool.getRelativeFilePath: return empty string instead of null for cross-drive paths

### DIFF
--- a/src/main/java/org/apache/maven/shared/utils/PathTool.java
+++ b/src/main/java/org/apache/maven/shared/utils/PathTool.java
@@ -164,14 +164,14 @@ public class PathTool {
                 && (!toPath.substring(0, 1).equals(fromPath.substring(0, 1)))) {
             // they both have drive path element but they dont match, no
             // relative path
-            return null;
+            return "";
         }
 
         if ((toPath.startsWith(":", 1) && !fromPath.startsWith(":", 1))
                 || (!toPath.startsWith(":", 1) && fromPath.startsWith(":", 1))) {
             // one has a drive path element and the other doesnt, no relative
             // path.
-            return null;
+            return "";
         }
 
         String resultPath = buildRelativePath(toPath, fromPath, File.separatorChar);

--- a/src/test/java/org/apache/maven/shared/utils/PathToolTest.java
+++ b/src/test/java/org/apache/maven/shared/utils/PathToolTest.java
@@ -57,10 +57,12 @@ public class PathToolTest {
         assertEquals("../../bin", PathTool.getRelativeFilePath("/usr/local/", "/bin"));
 
         assertEquals("../usr/local/", PathTool.getRelativeFilePath("/bin", "/usr/local/"));
+
+        assertEquals("", PathTool.getRelativeFilePath("c:/usr/local", "d:/java/bin"));
     }
 
     @Test
-    // Keep in sync with testGetRelativeFilePathNonWindows()
+    // Keep in sync with testGetRelativeFilePathWindows()
     @EnabledOnOs(OS.WINDOWS)
     public void testGetRelativeFilePathWindows() {
         assertEquals("", PathTool.getRelativeFilePath(null, null));
@@ -85,6 +87,8 @@ public class PathToolTest {
         assertEquals("..\\..\\bin", PathTool.getRelativeFilePath("c:\\usr\\local\\", "c:\\bin"));
 
         assertEquals("..\\usr\\local\\", PathTool.getRelativeFilePath("c:\\bin", "c:\\usr\\local\\"));
+
+        assertEquals("", PathTool.getRelativeFilePath("c:\\usr\\local", "d:\\java\\bin"));
     }
 
     @Test

--- a/src/test/java/org/apache/maven/shared/utils/PathToolTest.java
+++ b/src/test/java/org/apache/maven/shared/utils/PathToolTest.java
@@ -62,7 +62,7 @@ public class PathToolTest {
     }
 
     @Test
-    // Keep in sync with testGetRelativeFilePathWindows()
+    // Keep in sync with testGetRelativeFilePathNonWindows()
     @EnabledOnOs(OS.WINDOWS)
     public void testGetRelativeFilePathWindows() {
         assertEquals("", PathTool.getRelativeFilePath(null, null));


### PR DESCRIPTION
Fixes https://github.com/apache/maven-shared-utils/issues/402