### PR TITLE
StringUtils leftPad/rightPad: handle empty delimiter without ArithmeticException

### DIFF
--- a/src/main/java/org/apache/maven/shared/utils/StringUtils.java
+++ b/src/main/java/org/apache/maven/shared/utils/StringUtils.java
@@ -1113,6 +1113,9 @@ public class StringUtils {
      */
     @NonNull
     public static String rightPad(@NonNull String str, int size, @NonNull String delim) {
+        if (delim.isEmpty()) {
+            return str;
+        }
         size = (size - str.length()) / delim.length();
         if (size > 0) {
             str += repeat(delim, size);
@@ -1147,6 +1150,9 @@ public class StringUtils {
      */
     @NonNull
     public static String leftPad(@NonNull String str, int size, @NonNull String delim) {
+        if (delim.isEmpty()) {
+            return str;
+        }
         size = (size - str.length()) / delim.length();
         if (size > 0) {
             str = repeat(delim, size) + str;

--- a/src/main/java/org/apache/maven/shared/utils/StringUtils.java
+++ b/src/main/java/org/apache/maven/shared/utils/StringUtils.java
@@ -1108,7 +1108,6 @@ public class StringUtils {
      * @param size  size to pad to
      * @param delim string to pad with
      * @return right padded String
-     * @throws ArithmeticException  if delim is the empty String
      * @throws NullPointerException if str or delim is <code>null</code>
      */
     @NonNull
@@ -1145,7 +1144,6 @@ public class StringUtils {
      * @param size  size to pad to
      * @param delim string to pad with
      * @return left padded String
-     * @throws ArithmeticException  if delim is the empty string
      * @throws NullPointerException if str or delim is null
      */
     @NonNull

--- a/src/test/java/org/apache/maven/shared/utils/StringUtilsTest.java
+++ b/src/test/java/org/apache/maven/shared/utils/StringUtilsTest.java
@@ -854,6 +854,11 @@ public class StringUtilsTest {
         assertEquals("*****dings", StringUtils.leftPad("dings", 10, "*"));
     }
 
+    @Test
+    public void testLeftPadEmptyDelim() {
+        assertEquals("dings", StringUtils.leftPad("dings", 10, ""));
+    }
+
     @SuppressWarnings("ConstantValue")
     @Test
     public void testLowerCase() {
@@ -1266,6 +1271,11 @@ public class StringUtilsTest {
         assertEquals("dings", StringUtils.rightPad("dings", 3, "+"));
 
         assertEquals("dings+++++", StringUtils.rightPad("dings", 10, "+"));
+    }
+
+    @Test
+    public void testRightPadEmptyDelim() {
+        assertEquals("dings", StringUtils.rightPad("dings", 10, ""));
     }
 
     @Test


### PR DESCRIPTION
Fixes https://github.com/apache/maven-shared-utils/issues/408