### PR TITLE
Fix documentation issues in site pages

### DIFF
--- a/src/site/apt/index.apt.vm
+++ b/src/site/apt/index.apt.vm
@@ -40,7 +40,7 @@ ${project.name}
 
 Why?
 
-   plexus-utils consisted mostly of code that originated in various Apache projects. 
+   plexus-utils consisted mostly of code that originated in various Apache projects.
    maven-shared-utils is based on those original Apache-source implementations.
 
 Why not commons?

--- a/src/site/apt/index.apt.vm
+++ b/src/site/apt/index.apt.vm
@@ -30,7 +30,7 @@
 ${project.name}
 
    This project aims to be a functional replacement for
-   {{{http://codehaus-plexus.github.io/plexus-utils/}plexus-utils}} in Maven.
+   {{{https://codehaus-plexus.github.io/plexus-utils/}plexus-utils}} in Maven.
    
    It is not a 100% API compatible replacement though but a replacement <with improvements>:
    lots of methods got cleaned up, generics got added and we dropped a lot of unused code.
@@ -40,13 +40,13 @@ ${project.name}
 
 Why?
 
-   plexus-utils consisted mostly of code that was forked from various Apache projects. 
-   maven-shared-utils is based on the original from the Apache sources.
+   plexus-utils consisted mostly of code that originated in various Apache projects. 
+   maven-shared-utils is based on those original Apache-source implementations.
 
 Why not commons?
 
-    We would prefer code to use commons-* where appropriate, but the plexus-utils became
-    slightly incompatible (different) from the commons over the years, so migrating is not
-    always a 1:1 operation. Migrating to maven-shared-utils is a 1:1 operation in most cases.
+    We would prefer code to use commons-* where appropriate, but plexus-utils became
+    slightly incompatible from the Commons versions over the years, so migrating is not
+    always a 1:1 operation. Migrating to Maven Shared Utils is a 1:1 operation in most cases.
 
   []

--- a/src/site/apt/index.apt.vm
+++ b/src/site/apt/index.apt.vm
@@ -41,7 +41,7 @@ ${project.name}
 Why?
 
    plexus-utils consisted mostly of code that originated in various Apache projects.
-   maven-shared-utils is based on those original Apache-source implementations.
+   Maven Shared Utils is based on those original Apache-source implementations.
 
 Why not commons?
 

--- a/src/site/site.xml
+++ b/src/site/site.xml
@@ -19,7 +19,7 @@ specific language governing permissions and limitations
 under the License.
 -->
 
-<project xmlns="http://maven.apache.org/DECORATION/1.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/DECORATION/1.0.0 http://maven.apache.org/xsd/decoration-1.0.0.xsd">
+<project xmlns="http://maven.apache.org/DECORATION/1.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/DECORATION/1.0.0 https://maven.apache.org/xsd/decoration-1.0.0.xsd">
 
   <body>
     <menu name="Overview">


### PR DESCRIPTION
Various documentation fixes:

- Upgrade plexus-utils link to HTTPS
- Reword "forked from" → "originated in" (more precise)
- Clarify ambiguous "the original" phrasing
- Remove redundant parenthetical "(different)"
- Use proper project reference "Commons versions"
- Use project display name "Maven Shared Utils"
- Upgrade XSD URL from HTTP to HTTPS in site.xml