### PR TITLE
Restore the common wording on the download page

### DIFF
--- a/src/site/xdoc/download.xml.vm
+++ b/src/site/xdoc/download.xml.vm
@@ -29,14 +29,14 @@ under the License.
 
       <p><strong>${project.name} ${project.version}</strong> is distributed in source format.</p>
 
-      <p>Use a source archive if you want to build ${project.name} yourself.</p>
+      <p>Use a source archive if you intend to build <strong>${project.name}</strong> yourself.</p>
 
-      <p>Otherwise, use the ready-made binary artifacts from the central repository.</p>
+      <p>Otherwise, simply use the ready-made binary artifacts from <strong>central repository</strong>.</p>
 
       <p><strong>${project.name}</strong> is distributed under the <a href="https://www.apache.org/licenses/">Apache License, version 2.0</a>.</p>
 
       <subsection name="Files">
-        
+
         <p>This is the current stable version of <strong>${project.name}</strong>.</p>
 
         <table>
@@ -58,16 +58,17 @@ under the License.
           </tbody>
         </table>
 
-        <p>You must verify the integrity of the downloaded file using the checksum (.sha512 file) or using the signature (.asc file).</p>
-        <p>Use the public KEYS that Apache Maven developers provide to verify.</p>
+        <p>It is essential that you <a href="https://www.apache.org/info/verification.html">verify the integrity</a> of the downloaded file
+          using the checksum (.sha512 file)
+          or using the signature (.asc file) against the public <a href="https://downloads.apache.org/maven/KEYS">KEYS</a> used by the Apache Maven developers.
+        </p>
 
       </subsection>
 
       <subsection name="Previous Versions">
-        <p>You must use the latest release version of ${project.name} to get new features and bug fixes.</p>
-        <p>Older releases exist on the archive site. These releases are not recommended.</p>
+        <p>It is strongly recommended to use the latest release version of <strong>${project.name}</strong> to take advantage of the newest features and bug fixes.</p>
+        <p>Older non-recommended releases can be found on our <a href="https://archive.apache.org/dist/maven/shared/">archive site</a>.</p>
       </subsection>
     </section>
   </body>
 </document>
-


### PR DESCRIPTION
The wording on this page had drifted from the text the rest of the Maven estate uses. This restores the shared wording so the page is identical to its counterparts apart from the distribution area and the artifact name.

Format is unchanged — this stays xdoc.

### This is not purely cosmetic

Diffing the rendered HTML before and after shows the reworded version had **silently dropped three hyperlinks**, leaving the text as plain prose:

- `https://www.apache.org/info/verification.html` (how to verify a download)
- `https://downloads.apache.org/maven/KEYS` (the signing keys)
- `https://archive.apache.org/dist/maven/…/` (the archive site)

Restoring the common wording restores all three.

Headings, generated anchors (`#Files`, `#Previous_Versions`) and the table are unchanged, so no URL and no in-page anchor moves.

Verified by local site build and HTML diff only — not claiming CI is green; draft until it is.

---

**Licence header:** left byte-for-byte as it was. My first pass spliced in a canonical header and silently downgraded an `https://` LICENSE-2.0 URL to `http://` in a sibling repo; the generator now preserves each file's existing preamble and never rewrites it.

**Format:** this stays xdoc. Converting the page to Markdown was evaluated separately and shown to round-trip losslessly, and was then deliberately declined — noting that here so the question does not get reopened from scratch later.