### PR TITLE
Fix stale cross-drive assertion that has left master red since #384

### DIFF
--- a/src/test/java/org/apache/maven/shared/utils/PathToolTest.java
+++ b/src/test/java/org/apache/maven/shared/utils/PathToolTest.java
@@ -110,8 +110,8 @@ public class PathToolTest {
     public void testGetRelativeFilePathWithDifferentWindowsDrives() {
         // Verifies that a leading backslash before a Windows drive letter (e.g. "\C:\\...")
         // is stripped so the drive-letter comparison logic runs.
-        // Different drives should return null.
-        assertNull(PathTool.getRelativeFilePath("\\C:\\usr\\local", "\\D:\\usr\\local\\java\\bin"));
+        // Different drives have no relative path, represented as an empty string.
+        assertEquals("", PathTool.getRelativeFilePath("\\C:\\usr\\local", "\\D:\\usr\\local\\java\\bin"));
     }
 
     @Test


### PR DESCRIPTION
Master has failed `PathToolTest.testGetRelativeFilePathWithDifferentWindowsDrives` since 2026-08-03, on every JDK.

[#403](https://github.com/apache/maven-shared-utils/pull/403) changed `getRelativeFilePath` to return an empty string rather than `null` for paths on different Windows drives. [#384](https://github.com/apache/maven-shared-utils/pull/384) was branched before that change and merged the same day without a rebase, so the test it added still asserts `null`. Both PRs were green on their own branches, which is why CI did not catch it.

This switches that one assertion to the empty string. #403 is the newer contract and PathToolTest already asserts it in two other tests, so the assertion is the stale side, not the code.

Verified: `mvn -B verify` on JDK 17 -> Tests run: 787, Failures: 0, Errors: 0.

*This change was created with AI assistance.*
