### PR TITLE
Deprecate the logging package in favor of MessageBuilderFactory

### DIFF
--- a/src/main/java/org/apache/maven/shared/utils/logging/AnsiMessageBuilder.java
+++ b/src/main/java/org/apache/maven/shared/utils/logging/AnsiMessageBuilder.java
@@ -23,7 +23,11 @@ import org.fusesource.jansi.Ansi;
 /**
  * Message builder implementation that supports ANSI colors through
  * <a href="http://fusesource.github.io/jansi/">Jansi</a> with configurable styles through {@link Style}.
+ *
+ * @deprecated use {@code org.apache.maven.message.MessageBuilderFactory} (Maven 3.10.0 and later)
+ *             or {@code org.apache.maven.api.services.MessageBuilderFactory} (Maven 4) instead
  */
+@Deprecated
 class AnsiMessageBuilder implements MessageBuilder, LoggerLevelRenderer {
     private Ansi ansi;
 

--- a/src/main/java/org/apache/maven/shared/utils/logging/LoggerLevelRenderer.java
+++ b/src/main/java/org/apache/maven/shared/utils/logging/LoggerLevelRenderer.java
@@ -23,7 +23,10 @@ package org.apache.maven.shared.utils.logging;
  * logger level.
  *
  * @since 3.2.0
+ * @deprecated use {@code org.apache.maven.message.MessageBuilderFactory} (Maven 3.10.0 and later)
+ *             or {@code org.apache.maven.api.services.MessageBuilderFactory} (Maven 4) instead
  */
+@Deprecated
 public interface LoggerLevelRenderer {
     /**
      * Render a message at DEBUG level.

--- a/src/main/java/org/apache/maven/shared/utils/logging/MessageBuilder.java
+++ b/src/main/java/org/apache/maven/shared/utils/logging/MessageBuilder.java
@@ -28,7 +28,10 @@ import java.util.Formatter;
  *
  * @see MessageUtils
  * @since 3.1.0
+ * @deprecated use {@code org.apache.maven.message.MessageBuilderFactory} (Maven 3.10.0 and later)
+ *             or {@code org.apache.maven.api.services.MessageBuilderFactory} (Maven 4) instead
  */
+@Deprecated
 public interface MessageBuilder {
     /**
      * Append message content in success style.

--- a/src/main/java/org/apache/maven/shared/utils/logging/MessageUtils.java
+++ b/src/main/java/org/apache/maven/shared/utils/logging/MessageUtils.java
@@ -30,7 +30,10 @@ import org.fusesource.jansi.AnsiMode;
  * <a href="https://en.wikipedia.org/wiki/ANSI_escape_code#Colors">ANSI colors</a> on any platform.
  *
  * @since 3.1.0
+ * @deprecated use {@code org.apache.maven.message.MessageBuilderFactory} (Maven 3.10.0 and later)
+ *             or {@code org.apache.maven.api.services.MessageBuilderFactory} (Maven 4) instead
  */
+@Deprecated
 public class MessageUtils {
     private static final boolean JANSI;
 

--- a/src/main/java/org/apache/maven/shared/utils/logging/PlainMessageBuilder.java
+++ b/src/main/java/org/apache/maven/shared/utils/logging/PlainMessageBuilder.java
@@ -20,7 +20,11 @@ package org.apache.maven.shared.utils.logging;
 
 /**
  * Message builder implementation that just ignores styling, for Maven version earlier than 3.5.0.
+ *
+ * @deprecated use {@code org.apache.maven.message.MessageBuilderFactory} (Maven 3.10.0 and later)
+ *             or {@code org.apache.maven.api.services.MessageBuilderFactory} (Maven 4) instead
  */
+@Deprecated
 class PlainMessageBuilder implements MessageBuilder, LoggerLevelRenderer {
     private StringBuilder buffer;
 

--- a/src/main/java/org/apache/maven/shared/utils/logging/Style.java
+++ b/src/main/java/org/apache/maven/shared/utils/logging/Style.java
@@ -27,7 +27,10 @@ import org.fusesource.jansi.Ansi.Color;
  * Configurable message styles.
  *
  * @since 3.1.0
+ * @deprecated use {@code org.apache.maven.message.MessageBuilderFactory} (Maven 3.10.0 and later)
+ *             or {@code org.apache.maven.api.services.MessageBuilderFactory} (Maven 4) instead
  */
+@Deprecated
 enum Style {
     DEBUG("bold,cyan"),
     INFO("bold,blue"),


### PR DESCRIPTION
Deprecates `org.apache.maven.shared.utils.logging`. Maven 3.10.0 introduces `org.apache.maven.message.MessageBuilderFactory` and Maven 4 `org.apache.maven.api.services.MessageBuilderFactory`, both of which supersede it.

This is the outcome of the review on [#377](https://github.com/apache/maven-shared-utils/pull/377), which proposed swapping Jansi for `org.jline:jansi` here:

> It is no so easy, this class is used by Maven until 3.9.x and many plugins .... Maven also exports such packages. In Maven 3.10.x we will MessageBuilderFactory class. So I will not touch it, we can make it deprecated.

Marking the package-private implementations as well keeps the build free of warnings for implementing a deprecated interface. No behaviour changes and no signature changes, so this is source and binary compatible.

Closes [#373](https://github.com/apache/maven-shared-utils/issues/373).

Verified: `mvn -B verify` on JDK 17 -> Tests run: 787, Failures: 0, Errors: 0. Spotless clean.

*This change was created with AI assistance.*
