### PR TITLE
PropertyUtils: stop closing the caller's InputStream

### DIFF
--- a/src/main/java/org/apache/maven/shared/utils/PropertyUtils.java
+++ b/src/main/java/org/apache/maven/shared/utils/PropertyUtils.java
@@ -90,11 +90,7 @@ public class PropertyUtils {
         try {
             Properties result = new Properties();
             if (is != null) {
-                try (InputStream in = is) {
-                    result.load(in);
-                } catch (IOException e) {
-                    // ignore
-                }
+                result.load(is);
             }
             return result;
         } catch (Exception e) {
@@ -168,9 +164,8 @@ public class PropertyUtils {
         Properties properties = new Properties();
 
         if (inputStream != null) {
-            try (InputStream in = inputStream) // reassign inputStream to autoclose
-            {
-                properties.load(in);
+            try {
+                properties.load(inputStream);
             } catch (IllegalArgumentException | IOException ex) {
                 // ignore and return empty properties
             }

--- a/src/test/java/org/apache/maven/shared/utils/PropertyUtilsTest.java
+++ b/src/test/java/org/apache/maven/shared/utils/PropertyUtilsTest.java
@@ -29,6 +29,7 @@ import java.lang.annotation.Retention;
 import java.lang.annotation.RetentionPolicy;
 import java.lang.annotation.Target;
 import java.net.URL;
+import java.nio.charset.StandardCharsets;
 import java.nio.file.Files;
 import java.util.Properties;
 
@@ -50,7 +51,6 @@ public class PropertyUtilsTest {
 
     @Test
     @SuppressWarnings("deprecation")
-    // @ReproducesPlexusBug( "Should return null on error like url and file do" )
     public void loadNullInputStream() {
         assertEquals(new Properties(), PropertyUtils.loadProperties((InputStream) null));
     }
@@ -157,6 +157,22 @@ public class PropertyUtilsTest {
             assertEquals(
                     value, PropertyUtils.loadOptionalProperties(valid.toURI().toURL()));
         }
+    }
+
+    @Test
+    @SuppressWarnings("deprecation")
+    public void streamIsNotClosedByLoadProperties() throws IOException {
+        ByteArrayInputStream stream = new ByteArrayInputStream("a=b".getBytes(StandardCharsets.ISO_8859_1));
+        PropertyUtils.loadProperties(stream);
+        assertEquals(0, stream.available());
+    }
+
+    @Test
+    @SuppressWarnings("deprecation")
+    public void streamIsNotClosedByLoadOptionalProperties() throws IOException {
+        ByteArrayInputStream stream = new ByteArrayInputStream("a=b".getBytes(StandardCharsets.ISO_8859_1));
+        PropertyUtils.loadOptionalProperties(stream);
+        assertEquals(0, stream.available());
     }
 
     private static File newFile(File parent, String child) throws IOException {


### PR DESCRIPTION
`PropertyUtils.loadProperties(InputStream)` and `loadOptionalProperties(InputStream)` close the stream the caller handed them, via a try-with-resources that re-binds the parameter. A method that did not open a stream should not close it -- the caller may still need it, and closing it is invisible from the signature.

Fixes [#274](https://github.com/apache/maven-shared-utils/issues/274).

The commit is [Elliotte Rusty Harold](https://github.com/elharo)'s, cherry-picked from the `fix/propertyutils-stream-close` branch he pushed here on 2026-07-01 and never opened as a PR. Authorship is preserved. The only thing added on top is `spotless:apply` output, since that branch predates a formatting change on `master`. Opening it because the fix is finished and 3.5.0 is close; happy to hand it back if he would rather carry it himself.

Note for reviewers: this is a behaviour change. Callers that relied on the accidental close now have to close their own stream. That is the point of the issue, but it is worth a moment's thought before merging.

Verified: `mvn -B verify` on JDK 17 -> Tests run: 789, Failures: 0, Errors: 0. Spotless clean.

*This change was created with AI assistance.*
