### PR TITLE
Os.getOsFamily: return an empty string instead of null

### DIFF
--- a/src/main/java/org/apache/maven/shared/utils/Os.java
+++ b/src/main/java/org/apache/maven/shared/utils/Os.java
@@ -365,7 +365,7 @@ public class Os {
                 return fam;
             }
         }
-        return null;
+        return "";
     }
 
     /**

--- a/src/test/java/org/apache/maven/shared/utils/OsTest.java
+++ b/src/test/java/org/apache/maven/shared/utils/OsTest.java
@@ -26,6 +26,7 @@ import org.junit.jupiter.api.Test;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
 /**
@@ -110,6 +111,11 @@ public class OsTest {
         assertTrue(osFamilies.contains(Os.FAMILY_WIN9X));
         assertTrue(osFamilies.contains(Os.FAMILY_WINDOWS));
         assertTrue(osFamilies.contains(Os.FAMILY_ZOS));
+    }
+
+    @Test
+    public void testOsFamilyNotNull() {
+        assertNotNull(Os.OS_FAMILY);
     }
 
     @Test

--- a/src/test/java/org/apache/maven/shared/utils/OsTest.java
+++ b/src/test/java/org/apache/maven/shared/utils/OsTest.java
@@ -26,7 +26,6 @@ import org.junit.jupiter.api.Test;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
-import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
 /**
@@ -114,8 +113,8 @@ public class OsTest {
     }
 
     @Test
-    public void testOsFamilyNotNull() {
-        assertNotNull(Os.OS_FAMILY);
+    public void testOsFamilyIsValidFamily() {
+        assertTrue(Os.isValidFamily(Os.OS_FAMILY));
     }
 
     @Test


### PR DESCRIPTION
`Os.getOsFamily()` returns `null` when the current OS matches none of the known families, so `Os.OS_FAMILY` can be null and every caller has to guard for it. Returning an empty string removes that trap.

This matches the direction already taken in [#403](https://github.com/apache/maven-shared-utils/pull/403), where `PathTool.getRelativeFilePath` moved from `null` to `""` for the no-answer case.

The commit is [Elliotte Rusty Harold](https://github.com/elharo)'s, cherry-picked from the `fix/os-getosfamily-null` branch he pushed here on 2026-07-01 and never opened as a PR. Authorship is preserved, and the code is unchanged. Opening it because the fix is finished and 3.5.0 is close; happy to hand it back if he would rather carry it himself.

Note for reviewers: this is a behaviour change on a public constant. A caller testing `Os.OS_FAMILY == null` silently stops matching. In practice the branch is only reachable on an OS none of the families cover, and `Os` is deprecated in 3.5.0 in favour of `org.apache.commons.lang3.SystemUtils`, so the exposure is small -- but it is not zero.

Verified: `mvn -B verify` on JDK 17 -> Tests run: 788, Failures: 0, Errors: 0. Spotless clean.

*This change was created with AI assistance.*
