### PR TITLE
Xpp3DomWriter: reject a null dom with a named NullPointerException

### DIFF
--- a/src/main/java/org/apache/maven/shared/utils/xml/Xpp3DomWriter.java
+++ b/src/main/java/org/apache/maven/shared/utils/xml/Xpp3DomWriter.java
@@ -21,6 +21,7 @@ package org.apache.maven.shared.utils.xml;
 import java.io.IOException;
 import java.io.PrintWriter;
 import java.io.Writer;
+import java.util.Objects;
 
 /**
  * @author Brett Porter
@@ -62,6 +63,7 @@ public class Xpp3DomWriter {
      * @throws IOException if writing fails
      */
     public static void write(XMLWriter xmlWriter, Xpp3Dom dom, boolean escape) throws IOException {
+        Objects.requireNonNull(dom, "dom must not be null");
         xmlWriter.startElement(dom.getName());
         String[] attributeNames = dom.getAttributeNames();
         for (String attributeName : attributeNames) {

--- a/src/test/java/org/apache/maven/shared/utils/xml/Xpp3DomWriterTest.java
+++ b/src/test/java/org/apache/maven/shared/utils/xml/Xpp3DomWriterTest.java
@@ -1,0 +1,32 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.maven.shared.utils.xml;
+
+import java.io.StringWriter;
+
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.assertThrows;
+
+class Xpp3DomWriterTest {
+    @Test
+    void writeNullDom() {
+        assertThrows(NullPointerException.class, () -> Xpp3DomWriter.write(new StringWriter(), null));
+    }
+}


### PR DESCRIPTION
`Xpp3DomWriter.write` dereferences `dom` immediately, so a null argument already fails with a bare `NullPointerException` and no indication of which argument was wrong. `Objects.requireNonNull` names it, and a test pins the behaviour.

The commit is [Elliotte Rusty Harold](https://github.com/elharo)'s, cherry-picked from the `fix/xpp3domwriter-null-dom` branch he pushed here on 2026-07-01 and never opened as a PR. Authorship is preserved, and the code is unchanged. Opening it because the fix is finished and 3.5.0 is close; happy to hand it back if he would rather carry it himself.

No behaviour change beyond the message: the call threw `NullPointerException` before and still does. It also adds `Xpp3DomWriterTest`, which the class had none of.

`Xpp3DomWriter` is deprecated in 3.5.0, so this is a diagnostics improvement on a class on its way out rather than new investment.

Verified: `mvn -B verify` on JDK 17 -> Tests run: 788, Failures: 0, Errors: 0. Spotless clean.

*This change was created with AI assistance.*
