### PR TITLE
Correct the class names the deprecation notes point at

### DIFF
--- a/src/main/java/org/apache/maven/shared/utils/ReaderFactory.java
+++ b/src/main/java/org/apache/maven/shared/utils/ReaderFactory.java
@@ -47,7 +47,7 @@ public class ReaderFactory {
      * ISO Latin Alphabet #1, also known as ISO-LATIN-1.
      * Every implementation of the Java platform is required to support this character encoding.
      *
-     * @deprecated use {@code java.nio.charset.StandardCharset.ISO_8859_1}
+     * @deprecated use {@code java.nio.charset.StandardCharsets.ISO_8859_1}
      */
     @Deprecated
     public static final String ISO_8859_1 = "ISO-8859-1";
@@ -56,7 +56,7 @@ public class ReaderFactory {
      * Seven-bit ASCII, also known as ISO646-US, also known as the Basic Latin block of the Unicode character set.
      * Every implementation of the Java platform is required to support this character encoding.
      *
-     * @deprecated use {@code java.nio.charset.StandardCharset.US_ASCII}
+     * @deprecated use {@code java.nio.charset.StandardCharsets.US_ASCII}
      */
     @Deprecated
     public static final String US_ASCII = "US-ASCII";
@@ -66,7 +66,7 @@ public class ReaderFactory {
      * order accepted on input, big-endian used on output).
      * Every implementation of the Java platform is required to support this character encoding.
      *
-     * @deprecated use {@code java.nio.charset.StandardCharset.UTF_16}
+     * @deprecated use {@code java.nio.charset.StandardCharsets.UTF_16}
      */
     @Deprecated
     public static final String UTF_16 = "UTF-16";
@@ -75,7 +75,7 @@ public class ReaderFactory {
      * Sixteen-bit Unicode Transformation Format, big-endian byte order.
      * Every implementation of the Java platform is required to support this character encoding.
      *
-     * @deprecated use {@code java.nio.charset.StandardCharset.UTF_16BE}
+     * @deprecated use {@code java.nio.charset.StandardCharsets.UTF_16BE}
      */
     @Deprecated
     public static final String UTF_16BE = "UTF-16BE";
@@ -84,7 +84,7 @@ public class ReaderFactory {
      * Sixteen-bit Unicode Transformation Format, little-endian byte order.
      * Every implementation of the Java platform is required to support this character encoding.
      *
-     * @deprecated use {@code java.nio.charset.StandardCharset.UTF_16LE}
+     * @deprecated use {@code java.nio.charset.StandardCharsets.UTF_16LE}
      */
     @Deprecated
     public static final String UTF_16LE = "UTF-16LE";
@@ -93,7 +93,7 @@ public class ReaderFactory {
      * Eight-bit Unicode Transformation Format.
      * Every implementation of the Java platform is required to support this character encoding.
      *
-     * @deprecated use {@code java.nio.charset.StandardCharset.UTF_8}
+     * @deprecated use {@code java.nio.charset.StandardCharsets.UTF_8}
      */
     @Deprecated
     public static final String UTF_8 = "UTF-8";
@@ -101,7 +101,7 @@ public class ReaderFactory {
     /**
      * The <code>file.encoding</code> System Property.
      *
-     * @deprecated use {@code java.nio.charset.Charset.getDefaultCharset()}
+     * @deprecated use {@code java.nio.charset.Charset.defaultCharset()}
      */
     @Deprecated
     public static final String FILE_ENCODING = Charset.defaultCharset().displayName();
@@ -125,7 +125,7 @@ public class ReaderFactory {
      * @param file not null file
      * @return an XML reader instance for the input file
      * @throws IOException if any
-     * @deprecated use {}@code org.apache.commons.io.input.XmlStreamReader} instead
+     * @deprecated use {@code org.apache.commons.io.input.XmlStreamReader} instead
      */
     @Deprecated
     public static Reader newXmlReader(@NonNull File file) throws IOException {

--- a/src/main/java/org/apache/maven/shared/utils/StringUtils.java
+++ b/src/main/java/org/apache/maven/shared/utils/StringUtils.java
@@ -204,7 +204,7 @@ public class StringUtils {
      * @return <code>true</code> if the Strings are equal, case-sensitive, or
      *         both <code>null</code>
      * @see java.lang.String#equals(Object)
-     * @deprecated use {@code java.lang.Objects.equals()}
+     * @deprecated use {@code java.util.Objects.equals()}
      */
     @Deprecated
     public static boolean equals(@Nullable String str1, @Nullable String str2) {
@@ -1689,7 +1689,7 @@ public class StringUtils {
      * @param obj the Object to check
      * @return the passed in Object's toString, or blank if it was
      *         <code>null</code>
-     * @deprecated use {@code java.lang.Objects.toString()}
+     * @deprecated use {@code java.util.Objects.toString()}
      */
     @Deprecated
     @NonNull
@@ -1707,7 +1707,7 @@ public class StringUtils {
      *                      <code>null</code>
      * @return the passed in string, or the default if it was
      *         <code>null</code>
-     * @deprecated use {@code java.lang.Objects.toString()}
+     * @deprecated use {@code java.util.Objects.toString()}
      */
     @Deprecated
     @NonNull

--- a/src/main/java/org/apache/maven/shared/utils/WriterFactory.java
+++ b/src/main/java/org/apache/maven/shared/utils/WriterFactory.java
@@ -46,7 +46,7 @@ public class WriterFactory {
      * ISO Latin Alphabet #1, also known as ISO-LATIN-1.
      * Every implementation of the Java platform is required to support this character encoding.
      *
-     * @deprecated use {@code java.nio.charset.StandardCharset.ISO_8859_1}
+     * @deprecated use {@code java.nio.charset.StandardCharsets.ISO_8859_1}
      */
     @Deprecated
     public static final String ISO_8859_1 = "ISO-8859-1";
@@ -55,7 +55,7 @@ public class WriterFactory {
      * Seven-bit ASCII, also known as ISO646-US, also known as the Basic Latin block of the Unicode character set.
      * Every implementation of the Java platform is required to support this character encoding.
      *
-     * @deprecated use {@code java.nio.charset.StandardCharset.US_ASCII}
+     * @deprecated use {@code java.nio.charset.StandardCharsets.US_ASCII}
      */
     @Deprecated
     public static final String US_ASCII = "US-ASCII";
@@ -65,7 +65,7 @@ public class WriterFactory {
      * order accepted on input, big-endian used on output).
      * Every implementation of the Java platform is required to support this character encoding.
      *
-     * @deprecated use {@code java.nio.charset.StandardCharset.UTF_16}
+     * @deprecated use {@code java.nio.charset.StandardCharsets.UTF_16}
      */
     @Deprecated
     public static final String UTF_16 = "UTF-16";
@@ -74,7 +74,7 @@ public class WriterFactory {
      * Sixteen-bit Unicode Transformation Format, big-endian byte order.
      * Every implementation of the Java platform is required to support this character encoding.
      *
-     * @deprecated use {@code java.nio.charset.StandardCharset.UTF_16BE}
+     * @deprecated use {@code java.nio.charset.StandardCharsets.UTF_16BE}
      */
     @Deprecated
     public static final String UTF_16BE = "UTF-16BE";
@@ -83,7 +83,7 @@ public class WriterFactory {
      * Sixteen-bit Unicode Transformation Format, little-endian byte order.
      * Every implementation of the Java platform is required to support this character encoding.
      *
-     * @deprecated use {@code java.nio.charset.StandardCharset.UTF_16LE}
+     * @deprecated use {@code java.nio.charset.StandardCharsets.UTF_16LE}
      */
     @Deprecated
     public static final String UTF_16LE = "UTF-16LE";
@@ -92,7 +92,7 @@ public class WriterFactory {
      * Eight-bit Unicode Transformation Format.
      * Every implementation of the Java platform is required to support this character encoding.
      *
-     * @deprecated use {@code java.nio.charset.StandardCharset.UTF_8}
+     * @deprecated use {@code java.nio.charset.StandardCharsets.UTF_8}
      */
     @Deprecated
     public static final String UTF_8 = "UTF-8";
@@ -100,7 +100,7 @@ public class WriterFactory {
     /**
      * The <code>file.encoding</code> System Property.
      *
-     * @deprecated use {@code java.nio.charset.Charset.getDefaultCharset()}
+     * @deprecated use {@code java.nio.charset.Charset.defaultCharset()}
      */
     @Deprecated
     public static final String FILE_ENCODING = Charset.defaultCharset().displayName();
@@ -112,7 +112,7 @@ public class WriterFactory {
      * @return an XML writer instance for the output stream
      * @throws IOException if any
      * @see XmlStreamWriter
-     * @deprecated use {@code org.apache.commons.io.input.XmlStreamWriter} instead
+     * @deprecated use {@code org.apache.commons.io.output.XmlStreamWriter} instead
      */
     @Deprecated
     public static XmlStreamWriter newXmlWriter(@NonNull OutputStream out) throws IOException {
@@ -126,7 +126,7 @@ public class WriterFactory {
      * @return an XML writer instance for the output file
      * @throws IOException if any
      * @see XmlStreamWriter
-     * @deprecated use {@code org.apache.commons.io.input.XmlStreamWriter} instead
+     * @deprecated use {@code org.apache.commons.io.output.XmlStreamWriter} instead
      */
     @Deprecated
     public static XmlStreamWriter newXmlWriter(@NonNull File file) throws IOException {

--- a/src/main/java/org/apache/maven/shared/utils/io/DirectoryScanner.java
+++ b/src/main/java/org/apache/maven/shared/utils/io/DirectoryScanner.java
@@ -114,7 +114,7 @@ import org.jspecify.annotations.Nullable;
  * @author Magesh Umasankar
  * @author <a href="mailto:bruce@callenish.com">Bruce Atherton</a>
  * @author <a href="mailto:levylambert@tiscali-dsl.de">Antoine Levy-Lambert</a>
- * @deprecated use {@code java.nio.file.DirectoryStream} or {@code java.nio.Files.walkFileTree()}
+ * @deprecated use {@code java.nio.file.DirectoryStream} or {@code java.nio.file.Files.walkFileTree()}
  *             and related classes
  */
 @Deprecated

--- a/src/main/java/org/apache/maven/shared/utils/io/FileUtils.java
+++ b/src/main/java/org/apache/maven/shared/utils/io/FileUtils.java
@@ -231,7 +231,7 @@ public class FileUtils {
      * @param file the file path
      * @return the file content using the platform encoding
      * @throws IOException if any
-     * @deprecated use {@code new String(java.nio.files.Files.readAllBytes(file))}
+     * @deprecated use {@code new String(java.nio.file.Files.readAllBytes(file))}
      */
     @Deprecated
     @NonNull
@@ -244,7 +244,7 @@ public class FileUtils {
      * @param encoding the wanted encoding
      * @return the file content using the specified encoding
      * @throws IOException if any
-     * @deprecated use {@code new String(java.nio.files.Files.readAllBytes(Paths.get(file)), encoding)}
+     * @deprecated use {@code new String(java.nio.file.Files.readAllBytes(Paths.get(file)), encoding)}
      */
     @Deprecated
     @NonNull
@@ -258,7 +258,7 @@ public class FileUtils {
      * @param file the file path
      * @return the file content using the platform encoding
      * @throws IOException if any
-     * @deprecated use {@code new String(java.nio.files.Files.readAllBytes(file.toPath()))}
+     * @deprecated use {@code new String(java.nio.file.Files.readAllBytes(file.toPath()))}
      */
     @Deprecated
     @NonNull
@@ -271,7 +271,7 @@ public class FileUtils {
      * @param encoding the wanted encoding
      * @return the file content using the specified encoding
      * @throws IOException if any
-     * @deprecated use {@code new String(java.nio.files.Files.readAllBytes(file.toPath()), encoding)}
+     * @deprecated use {@code new String(java.nio.file.Files.readAllBytes(file.toPath()), encoding)}
      */
     @Deprecated
     @NonNull
@@ -297,7 +297,7 @@ public class FileUtils {
      * @return the file content lines as String[] using the system default encoding.
      * An empty List if the file doesn't exist.
      * @throws IOException in case of failure
-     * @deprecated use {@code java.nio.files.Files.readAllLines()}
+     * @deprecated use {@code java.nio.file.Files.readAllLines()}
      */
     @Deprecated
     @NonNull
@@ -314,7 +314,7 @@ public class FileUtils {
      * @param fileName the path of the file to write
      * @param data     the content to write to the file
      * @throws IOException if any
-     * @deprecated use {@code java.nio.files.Files.write(filename, data.getBytes(),
+     * @deprecated use {@code java.nio.file.Files.write(filename, data.getBytes(),
      *     StandardOpenOption.APPEND, StandardOpenOption.CREATE)}
      */
     @Deprecated
@@ -329,7 +329,7 @@ public class FileUtils {
      * @param encoding the encoding of the file
      * @param data     the content to write to the file
      * @throws IOException if any
-     * @deprecated use {@code java.nio.files.Files.write(filename, data.getBytes(encoding),
+     * @deprecated use {@code java.nio.file.Files.write(filename, data.getBytes(encoding),
      *     StandardOpenOption.APPEND, StandardOpenOption.CREATE)}
      */
     @Deprecated
@@ -349,7 +349,7 @@ public class FileUtils {
      * @param fileName the path of the file to write
      * @param data     the content to write to the file
      * @throws IOException if any
-     * @deprecated use {@code java.nio.files.Files.write(filename,
+     * @deprecated use {@code java.nio.file.Files.write(filename,
      *     data.getBytes(), StandardOpenOption.CREATE)}
      */
     @Deprecated
@@ -364,7 +364,7 @@ public class FileUtils {
      * @param encoding the encoding of the file
      * @param data     the content to write to the file
      * @throws IOException if any
-     * @deprecated use {@code java.nio.files.Files.write(Paths.get(filename),
+     * @deprecated use {@code java.nio.file.Files.write(Paths.get(filename),
      *     data.getBytes(encoding), StandardOpenOption.CREATE)}
      */
     @Deprecated
@@ -381,7 +381,7 @@ public class FileUtils {
      * @param encoding the encoding of the file
      * @param data     the content to write to the file
      * @throws IOException if any
-     * @deprecated use {@code java.nio.files.Files.write(file.toPath(),
+     * @deprecated use {@code java.nio.file.Files.write(file.toPath(),
      *     data.getBytes(encoding), StandardOpenOption.CREATE)}
      */
     @Deprecated
@@ -401,7 +401,7 @@ public class FileUtils {
      * @param file the path of the file to write
      * @param data the content to write to the file
      * @throws IOException if any
-     * @deprecated use {@code java.nio.files.Files.write(file.toPath(),
+     * @deprecated use {@code java.nio.file.Files.write(file.toPath(),
      *     data.getBytes(encoding), StandardOpenOption.CREATE)}
      */
     @Deprecated
@@ -416,7 +416,7 @@ public class FileUtils {
      * @param encoding the encoding of the file
      * @param data the content to write to the file
      * @throws IOException if any
-     * @deprecated use {@code java.nio.files.Files.write(file.toPath(),
+     * @deprecated use {@code java.nio.file.Files.write(file.toPath(),
      *     data.getBytes(encoding), StandardOpenOption.CREATE)}
      */
     @Deprecated
@@ -727,7 +727,7 @@ public class FileUtils {
      * @throws IOException if <code>source</code> does not exist, <code>destination</code> cannot be
      *                     written to, or an IO error occurs during copying
      * @throws java.io.FileNotFoundException if <code>destination</code> is a directory
-     * @deprecated use {@code java.nio.Files.copy(source.toPath(), destination.toPath(), LinkOption.NOFOLLOW_LINKS,
+     * @deprecated use {@code java.nio.file.Files.copy(source.toPath(), destination.toPath(), LinkOption.NOFOLLOW_LINKS,
      *     StandardCopyOption.REPLACE_EXISTING)}
      */
     @Deprecated
@@ -823,7 +823,7 @@ public class FileUtils {
      *                     <li><code>destination</code> cannot be written to</li>
      *                     <li>an IO error occurs during copying</li>
      *                     </ul>
-     * @deprecated use {@code java.nio.Files.copy(source.openStream(), destination.toPath(),
+     * @deprecated use {@code java.nio.file.Files.copy(source.openStream(), destination.toPath(),
      *     StandardCopyOption.REPLACE_EXISTING)}
      */
     public static void copyURLToFile(@NonNull final URL source, @NonNull final File destination) throws IOException {
@@ -845,7 +845,7 @@ public class FileUtils {
      *                     <li><code>destination</code> cannot be written to</li>
      *                     <li>an I/O error occurs during copying</li>
      *                     </ul>
-     * @deprecated use {@code java.nio.Files.copy(source, destination.toPath(),
+     * @deprecated use {@code java.nio.file.Files.copy(source, destination.toPath(),
      *     StandardCopyOption.REPLACE_EXISTING)}
      */
     @Deprecated
@@ -886,7 +886,7 @@ public class FileUtils {
      *
      * @param path the path to normalize
      * @return the normalized String, or <code>null</code> if too many ..'s
-     * @deprecated use {@code org.apache.commons.io.FileNameUtils.normalize()}
+     * @deprecated use {@code org.apache.commons.io.FilenameUtils.normalize()}
      */
     @Deprecated
     @NonNull
@@ -1036,7 +1036,7 @@ public class FileUtils {
      *
      * @param file the file to delete
      * @throws IOException if the file cannot be deleted
-     * @deprecated use {@code java.nio.files.Files.delete(file.toPath())}
+     * @deprecated use {@code java.nio.file.Files.delete(file.toPath())}
      */
     @Deprecated
     public static void delete(@NonNull File file) throws IOException {
@@ -1046,7 +1046,7 @@ public class FileUtils {
     /**
      * @param file the file
      * @return true / false
-     * @deprecated use {@code java.nio.files.Files.delete(file.toPath())}
+     * @deprecated use {@code java.nio.file.Files.delete(file.toPath())}
      */
     @Deprecated
     public static boolean deleteLegacyStyle(@NonNull File file) {
@@ -1598,7 +1598,7 @@ public class FileUtils {
      * @param to   the new file name
      * @throws IOException if anything bad happens during this process.
      *                     Note that <code>to</code> may have been deleted already when this happens.
-     * @deprecated use {@code java.nio.Files.move()}
+     * @deprecated use {@code java.nio.file.Files.move()}
      */
     @Deprecated
     public static void rename(@NonNull File from, @NonNull File to) throws IOException {
@@ -1639,7 +1639,7 @@ public class FileUtils {
      * @param parentDir directory to create the temporary file in <code>-java.io.tmpdir</code>
      *                  used if not specified
      * @return a File reference to the new temporary file
-     * @deprecated use {@code java.nio.Files.createTempFile()}
+     * @deprecated use {@code java.nio.file.Files.createTempFile()}
      */
     @Deprecated
     public static File createTempFile(@NonNull String prefix, @NonNull String suffix, @Nullable File parentDir) {

--- a/src/main/java/org/apache/maven/shared/utils/xml/XmlStreamWriter.java
+++ b/src/main/java/org/apache/maven/shared/utils/xml/XmlStreamWriter.java
@@ -23,7 +23,7 @@ import java.io.FileNotFoundException;
 import java.io.OutputStream;
 
 /**
- * @deprecated use org.apache.commons.io.input.XmlStreamWriter instead
+ * @deprecated use org.apache.commons.io.output.XmlStreamWriter instead
  */
 @Deprecated
 public class XmlStreamWriter extends org.apache.commons.io.output.XmlStreamWriter {


### PR DESCRIPTION
42 references in `@deprecated` notes named classes that do not exist. Since 3.5.0 is largely a deprecation sweep, these notes are the migration advice, and as written a good part of it sends readers to packages that were never there.

| Wrong | Correct | Count |
|---|---|---|
| `java.nio.files.Files` | `java.nio.file.Files` | 14 |
| `java.nio.charset.StandardCharset` | `StandardCharsets` | 12 |
| `java.nio.Files` | `java.nio.file.Files` | 6 |
| `java.lang.Objects` | `java.util.Objects` | 3 |
| `commons.io.input.XmlStreamWriter` | `commons.io.output.XmlStreamWriter` | 3 |
| `Charset.getDefaultCharset` | `Charset.defaultCharset` | 2 |
| `commons.io.FileNameUtils` | `commons.io.FilenameUtils` | 1 |
| `{}@code` | `{@code` | 1 |

The commons-io packages were read from the 2.22.0 jar rather than assumed: `XmlStreamReader` is in `input`, `XmlStreamWriter` is in `output`. The `XmlStreamReader` references were already right and are untouched.

Javadoc text only across 6 files. No signature, behaviour or dependency changes.

Verified: `mvn -B javadoc:javadoc` -> BUILD SUCCESS. `mvn -B verify` on JDK 17 -> Tests run: 788, Failures: 0, Errors: 0. Spotless clean. The `no comment` warnings that remain are pre-existing and untouched.

*This change was created with AI assistance.*
