### PR TITLE
Drop the jspecify nullness annotations

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -79,11 +79,6 @@
       <version>2.4.3</version>
       <optional>true</optional>
     </dependency>
-    <dependency>
-      <groupId>org.jspecify</groupId>
-      <artifactId>jspecify</artifactId>
-      <version>1.0.1</version>
-    </dependency>
 
     <dependency>
       <groupId>commons-io</groupId>

--- a/src/main/java/org/apache/maven/shared/utils/PathTool.java
+++ b/src/main/java/org/apache/maven/shared/utils/PathTool.java
@@ -21,9 +21,6 @@ package org.apache.maven.shared.utils;
 import java.io.File;
 import java.util.StringTokenizer;
 
-import org.jspecify.annotations.NonNull;
-import org.jspecify.annotations.Nullable;
-
 /**
  * <p>Path tool contains static methods to assist in determining path-related
  * information such as relative paths.</p>
@@ -76,7 +73,7 @@ public class PathTool {
      * @deprecated use java.nio.file.Path.relativize() instead
      */
     @Deprecated
-    public static String getRelativePath(@Nullable String basedir, @Nullable String filename) {
+    public static String getRelativePath(String basedir, String filename) {
         basedir = uppercaseDrive(basedir);
         filename = uppercaseDrive(filename);
 
@@ -204,8 +201,7 @@ public class PathTool {
      *         terminated with a forward slash.  A zero-length string is
      *         returned if: the filename is zero-length.
      */
-    @NonNull
-    private static String determineRelativePath(@NonNull String filename, @NonNull String separator) {
+    private static String determineRelativePath(String filename, String separator) {
         if (filename.length() == 0) {
             return "";
         }
@@ -260,7 +256,7 @@ public class PathTool {
      * @param path old path
      * @return string
      */
-    static String uppercaseDrive(@Nullable String path) {
+    static String uppercaseDrive(String path) {
         if (path == null) {
             return null;
         }
@@ -270,9 +266,7 @@ public class PathTool {
         return path;
     }
 
-    @NonNull
-    private static String buildRelativePath(
-            @NonNull String toPath, @NonNull String fromPath, final char separatorChar) {
+    private static String buildRelativePath(String toPath, String fromPath, final char separatorChar) {
         // use tokeniser to traverse paths and for lazy checking
         StringTokenizer toTokeniser = new StringTokenizer(toPath, String.valueOf(separatorChar));
         StringTokenizer fromTokeniser = new StringTokenizer(fromPath, String.valueOf(separatorChar));

--- a/src/main/java/org/apache/maven/shared/utils/PropertyUtils.java
+++ b/src/main/java/org/apache/maven/shared/utils/PropertyUtils.java
@@ -25,9 +25,6 @@ import java.io.InputStream;
 import java.net.URL;
 import java.util.Properties;
 
-import org.jspecify.annotations.NonNull;
-import org.jspecify.annotations.Nullable;
-
 /**
  * Static utility methods for loading properties.
  */
@@ -49,7 +46,7 @@ public class PropertyUtils {
      *             instead of an empty {@code Properties} instance when the given {@code URL} is {@code null}.
      */
     @Deprecated
-    public static java.util.Properties loadProperties(@NonNull URL url) {
+    public static java.util.Properties loadProperties(URL url) {
         try (InputStream in = url.openStream()) {
             return loadProperties(in);
         } catch (Exception e) {
@@ -66,7 +63,7 @@ public class PropertyUtils {
      *             instead of an empty {@code Properties} instance when the given {@code File} is {@code null}.
      */
     @Deprecated
-    public static Properties loadProperties(@NonNull File file) {
+    public static Properties loadProperties(File file) {
         try (InputStream in = new FileInputStream(file)) {
             return loadProperties(in);
         } catch (Exception e) {
@@ -86,7 +83,7 @@ public class PropertyUtils {
      *             should not be used as it suppresses exceptions silently when loading properties fails.
      */
     @Deprecated
-    public static Properties loadProperties(@Nullable InputStream is) {
+    public static Properties loadProperties(InputStream is) {
         try {
             Properties result = new Properties();
             if (is != null) {
@@ -113,8 +110,7 @@ public class PropertyUtils {
      * @return the loaded properties or an empty {@code Properties} instance if properties fail to load
      * @since 3.1.0
      */
-    @NonNull
-    public static Properties loadOptionalProperties(final @Nullable URL url) {
+    public static Properties loadOptionalProperties(final URL url) {
 
         Properties properties = new Properties();
         if (url != null) {
@@ -138,8 +134,7 @@ public class PropertyUtils {
      * @return the loaded properties or an empty {@code Properties} instance if properties fail to load
      * @since 3.1.0
      */
-    @NonNull
-    public static Properties loadOptionalProperties(final @Nullable File file) {
+    public static Properties loadOptionalProperties(final File file) {
         Properties properties = new Properties();
         if (file != null) {
             try (InputStream in = new FileInputStream(file)) {
@@ -162,8 +157,7 @@ public class PropertyUtils {
      * @return the loaded properties or an empty {@code Properties} instance if properties fail to load
      * @since 3.1.0
      */
-    @NonNull
-    public static Properties loadOptionalProperties(final @Nullable InputStream inputStream) {
+    public static Properties loadOptionalProperties(final InputStream inputStream) {
 
         Properties properties = new Properties();
 

--- a/src/main/java/org/apache/maven/shared/utils/ReaderFactory.java
+++ b/src/main/java/org/apache/maven/shared/utils/ReaderFactory.java
@@ -31,7 +31,6 @@ import java.net.URL;
 import java.nio.charset.Charset;
 
 import org.apache.commons.io.input.XmlStreamReader;
-import org.jspecify.annotations.NonNull;
 
 /**
  * Utility to create Readers from streams, with explicit encoding choice: platform default,
@@ -115,7 +114,7 @@ public class ReaderFactory {
      * @deprecated use {@code org.apache.commons.io.input.XmlStreamReader} instead
      */
     @Deprecated
-    public static Reader newXmlReader(@NonNull InputStream in) throws IOException {
+    public static Reader newXmlReader(InputStream in) throws IOException {
         return new XmlStreamReader(in);
     }
 
@@ -128,7 +127,7 @@ public class ReaderFactory {
      * @deprecated use {@code org.apache.commons.io.input.XmlStreamReader} instead
      */
     @Deprecated
-    public static Reader newXmlReader(@NonNull File file) throws IOException {
+    public static Reader newXmlReader(File file) throws IOException {
         return new XmlStreamReader(file);
     }
 
@@ -141,7 +140,7 @@ public class ReaderFactory {
      * @deprecated use {@code org.apache.commons.io.input.XmlStreamReader} instead
      */
     @Deprecated
-    public static Reader newXmlReader(@NonNull URL url) throws IOException {
+    public static Reader newXmlReader(URL url) throws IOException {
         return new XmlStreamReader(url);
     }
 
@@ -155,7 +154,7 @@ public class ReaderFactory {
      * @deprecated always specify an encoding. Do not depend on the default platform character set.
      */
     @Deprecated
-    public static Reader newPlatformReader(@NonNull File file) throws FileNotFoundException {
+    public static Reader newPlatformReader(File file) throws FileNotFoundException {
         return new FileReader(file);
     }
 
@@ -172,8 +171,7 @@ public class ReaderFactory {
      * @deprecated use {@code new InputStreamReader(in, encoding)} instead
      */
     @Deprecated
-    public static Reader newReader(@NonNull InputStream in, @NonNull String encoding)
-            throws UnsupportedEncodingException {
+    public static Reader newReader(InputStream in, String encoding) throws UnsupportedEncodingException {
         return new InputStreamReader(in, encoding);
     }
 
@@ -192,7 +190,7 @@ public class ReaderFactory {
      *    or {@code new Files.newBufferedReader} instead
      */
     @Deprecated
-    public static Reader newReader(@NonNull File file, @NonNull String encoding)
+    public static Reader newReader(File file, String encoding)
             throws FileNotFoundException, UnsupportedEncodingException {
         return new InputStreamReader(new FileInputStream(file), encoding);
     }
@@ -211,7 +209,7 @@ public class ReaderFactory {
      * @deprecated This method does not use HTTP headers to detect the resource's encoding.
      */
     @Deprecated
-    public static Reader newReader(@NonNull URL url, @NonNull String encoding) throws IOException {
+    public static Reader newReader(URL url, String encoding) throws IOException {
         return new InputStreamReader(url.openStream(), encoding);
     }
 }

--- a/src/main/java/org/apache/maven/shared/utils/StringUtils.java
+++ b/src/main/java/org/apache/maven/shared/utils/StringUtils.java
@@ -24,9 +24,6 @@ import java.util.Locale;
 import java.util.Map;
 import java.util.StringTokenizer;
 
-import org.jspecify.annotations.NonNull;
-import org.jspecify.annotations.Nullable;
-
 /**
  * <p>Common <code>String</code> manipulation routines.</p>
  *
@@ -73,7 +70,6 @@ public class StringUtils {
      * @deprecated use {@link #trim(String)} instead.
      */
     @Deprecated
-    @NonNull
     public static String clean(String str) {
         return (str == null ? "" : str.trim());
     }
@@ -100,8 +96,7 @@ public class StringUtils {
      * @param str string target to delete whitespace from
      * @return the String without whitespace
      */
-    @NonNull
-    public static String deleteWhitespace(@NonNull String str) {
+    public static String deleteWhitespace(String str) {
         StringBuilder buffer = new StringBuilder();
         int sz = str.length();
         for (int i = 0; i < sz; i++) {
@@ -119,7 +114,7 @@ public class StringUtils {
      * @param str the String to check
      * @return true if the String is non-null, and not length zero
      */
-    public static boolean isNotEmpty(@Nullable String str) {
+    public static boolean isNotEmpty(String str) {
         return ((str != null) && (str.length() > 0));
     }
 
@@ -134,7 +129,7 @@ public class StringUtils {
      * @return <code>true</code> if the String is <code>null</code>, or
      *         length zero once trimmed
      */
-    public static boolean isEmpty(@Nullable String str) {
+    public static boolean isEmpty(String str) {
         return ((str == null) || (str.trim().length() == 0));
     }
 
@@ -154,7 +149,7 @@ public class StringUtils {
      * @param str the String to check, may be null
      * @return <code>true</code> if the String is null, empty or whitespace
      */
-    public static boolean isBlank(@Nullable String str) {
+    public static boolean isBlank(String str) {
         int strLen;
         // CHECKSTYLE_OFF: InnerAssignment
         if (str == null || (strLen = str.length()) == 0)
@@ -186,7 +181,7 @@ public class StringUtils {
      * @param str the String to check, may be null
      * @return <code>true</code> if the String is not empty and not null and not whitespace
      */
-    public static boolean isNotBlank(@Nullable String str) {
+    public static boolean isNotBlank(String str) {
         return !isBlank(str);
     }
 
@@ -207,7 +202,7 @@ public class StringUtils {
      * @deprecated use {@code java.util.Objects.equals()}
      */
     @Deprecated
-    public static boolean equals(@Nullable String str1, @Nullable String str2) {
+    public static boolean equals(String str1, String str2) {
         return (str1 == null ? str2 == null : str1.equals(str2));
     }
 
@@ -458,9 +453,8 @@ public class StringUtils {
      *      <code>String.split()</code> splits on a regular expression so while it can
      *      do anything this method does, it is not a drop-in replacement.
      */
-    @NonNull
     @Deprecated
-    public static String[] split(@NonNull String str) {
+    public static String[] split(String str) {
         return split(str, null, -1);
     }
 
@@ -473,9 +467,8 @@ public class StringUtils {
      *      <code>String.split()</code> splits on a regular expression so while it can
      *      do anything this method does, it is not a drop-in replacement.
      */
-    @NonNull
     @Deprecated
-    public static String[] split(@NonNull String text, @Nullable String separator) {
+    public static String[] split(String text, String separator) {
         return split(text, separator, -1);
     }
 
@@ -500,9 +493,8 @@ public class StringUtils {
      *      <code>String.split()</code> splits on a regular expression so while it can
      *      do anything this method does, it is not a drop-in replacement.
      */
-    @NonNull
     @Deprecated
-    public static String[] split(@NonNull String str, @Nullable String separator, int max) {
+    public static String[] split(String str, String separator, int max) {
         StringTokenizer tok;
         if (separator == null) {
             // Null separator means we're using StringTokenizer's default
@@ -554,8 +546,7 @@ public class StringUtils {
      *     <code>Arrays.stream(array).map(Object::toString).collect(Collectors.joining(""))</code> instead
      */
     @Deprecated
-    @NonNull
-    public static String concatenate(@NonNull Object... array) {
+    public static String concatenate(Object... array) {
         return join(array, "");
     }
 
@@ -573,8 +564,7 @@ public class StringUtils {
      *      <code>Arrays.stream(array).map(Object::toString).collect(Collectors.joining(separator))</code> instead
      */
     @Deprecated
-    @NonNull
-    public static String join(@NonNull Object[] array, @Nullable String separator) {
+    public static String join(Object[] array, String separator) {
         if (separator == null) {
             separator = "";
         }
@@ -604,8 +594,7 @@ public class StringUtils {
      * @deprecated use <code>java.lang.String.join()</code> instead
      */
     @Deprecated
-    @NonNull
-    public static String join(@NonNull Iterator<?> iterator, String separator) {
+    public static String join(Iterator<?> iterator, String separator) {
         if (separator == null) {
             separator = "";
         }
@@ -633,7 +622,7 @@ public class StringUtils {
      * @return the text with any replacements processed
      * @see #replace(String text, char repl, char with, int max)
      */
-    public static String replaceOnce(@Nullable String text, char repl, char with) {
+    public static String replaceOnce(String text, char repl, char with) {
         return replace(text, repl, with, 1);
     }
 
@@ -652,7 +641,7 @@ public class StringUtils {
      *             method returns <code>null</code>.
      */
     @Deprecated
-    public static String replace(@Nullable String text, char repl, char with) {
+    public static String replace(String text, char repl, char with) {
         return replace(text, repl, with, -1);
     }
 
@@ -668,7 +657,7 @@ public class StringUtils {
      * @param max  maximum number of values to replace, or <code>-1</code> if no maximum
      * @return the text with any replacements processed
      */
-    public static String replace(@Nullable String text, char repl, char with, int max) {
+    public static String replace(String text, char repl, char with, int max) {
         return replace(text, String.valueOf(repl), String.valueOf(with), max);
     }
 
@@ -683,7 +672,7 @@ public class StringUtils {
      * @return the text with any replacements processed
      * @see #replace(String text, String repl, String with, int max)
      */
-    public static String replaceOnce(@Nullable String text, @Nullable String repl, @Nullable String with) {
+    public static String replaceOnce(String text, String repl, String with) {
         return replace(text, repl, with, 1);
     }
 
@@ -703,7 +692,7 @@ public class StringUtils {
      *             returns <code>text</code> unchanged.
      */
     @Deprecated
-    public static String replace(@Nullable String text, @Nullable String repl, @Nullable String with) {
+    public static String replace(String text, String repl, String with) {
         return replace(text, repl, with, -1);
     }
 
@@ -719,7 +708,7 @@ public class StringUtils {
      * @param max  maximum number of values to replace, or <code>-1</code> if no maximum
      * @return the text with any replacements processed
      */
-    public static String replace(@Nullable String text, @Nullable String repl, @Nullable String with, int max) {
+    public static String replace(String text, String repl, String with, int max) {
         if ((text == null) || (repl == null) || (with == null) || (repl.length() == 0)) {
             return text;
         }
@@ -748,8 +737,7 @@ public class StringUtils {
      * @return string with overlaid text
      * @throws NullPointerException if text or overlay is <code>null</code>
      */
-    @NonNull
-    public static String overlayString(@NonNull String text, @NonNull String overlay, int start, int end) {
+    public static String overlayString(String text, String overlay, int start, int end) {
         if (overlay == null) {
             throw new NullPointerException("overlay is null");
         }
@@ -774,8 +762,7 @@ public class StringUtils {
      * @return string containing centered String
      * @throws NullPointerException if str is <code>null</code>
      */
-    @NonNull
-    public static String center(@NonNull String str, int size) {
+    public static String center(String str, int size) {
         return center(str, size, " ");
     }
 
@@ -791,8 +778,7 @@ public class StringUtils {
      * @throws ArithmeticException  if delim is the empty String
      * @throws NullPointerException if str or delim is <code>null</code>
      */
-    @NonNull
-    public static String center(@NonNull String str, int size, @NonNull String delim) {
+    public static String center(String str, int size, String delim) {
         int sz = str.length();
         int p = size - sz;
         if (p < 1) {
@@ -813,8 +799,7 @@ public class StringUtils {
      * @return string without chomped newline
      * @throws NullPointerException if str is <code>null</code>
      */
-    @NonNull
-    public static String chomp(@NonNull String str) {
+    public static String chomp(String str) {
         return chomp(str, "\n");
     }
 
@@ -827,8 +812,7 @@ public class StringUtils {
      * @return string without chomped ending
      * @throws NullPointerException if str or sep is <code>null</code>
      */
-    @NonNull
-    public static String chomp(@NonNull String str, @NonNull String sep) {
+    public static String chomp(String str, String sep) {
         int idx = str.lastIndexOf(sep);
         if (idx != -1) {
             return str.substring(0, idx);
@@ -845,8 +829,7 @@ public class StringUtils {
      * @return string without chomped ending
      * @throws NullPointerException if str is <code>null</code>
      */
-    @NonNull
-    public static String chompLast(@NonNull String str) {
+    public static String chompLast(String str) {
         return chompLast(str, "\n");
     }
 
@@ -858,8 +841,7 @@ public class StringUtils {
      * @return string without chomped ending
      * @throws NullPointerException if str or sep is <code>null</code>
      */
-    @NonNull
-    public static String chompLast(@NonNull String str, @NonNull String sep) {
+    public static String chompLast(String str, String sep) {
         if (str.length() == 0 || sep.length() > str.length()) {
             return str;
         }
@@ -880,8 +862,7 @@ public class StringUtils {
      * @return string chomped
      * @throws NullPointerException if str or sep is <code>null</code>
      */
-    @NonNull
-    public static String getChomp(@NonNull String str, @NonNull String sep) {
+    public static String getChomp(String str, String sep) {
         int idx = str.lastIndexOf(sep);
         if (idx == str.length() - sep.length()) {
             return sep;
@@ -901,8 +882,7 @@ public class StringUtils {
      * @return string without chomped beginning
      * @throws NullPointerException if str or sep is <code>null</code>
      */
-    @NonNull
-    public static String prechomp(@NonNull String str, @NonNull String sep) {
+    public static String prechomp(String str, String sep) {
         int idx = str.indexOf(sep);
         if (idx != -1) {
             return str.substring(idx + sep.length());
@@ -920,8 +900,7 @@ public class StringUtils {
      * @return string prechomped
      * @throws NullPointerException if str or sep is <code>null</code>
      */
-    @NonNull
-    public static String getPrechomp(@NonNull String str, @NonNull String sep) {
+    public static String getPrechomp(String str, String sep) {
         int idx = str.indexOf(sep);
         if (idx != -1) {
             return str.substring(0, idx + sep.length());
@@ -943,8 +922,7 @@ public class StringUtils {
      * @return string without last character
      * @throws NullPointerException if str is <code>null</code>
      */
-    @NonNull
-    public static String chop(@NonNull String str) {
+    public static String chop(String str) {
         if ("".equals(str)) {
             return "";
         }
@@ -970,8 +948,7 @@ public class StringUtils {
      * @return string without newline
      * @throws NullPointerException if str is <code>null</code>
      */
-    @NonNull
-    public static String chopNewline(@NonNull String str) {
+    public static String chopNewline(String str) {
         if (str.isEmpty()) {
             return "";
         }
@@ -1002,8 +979,7 @@ public class StringUtils {
      * @return string with escaped values
      * @throws NullPointerException if str is <code>null</code>
      */
-    @NonNull
-    public static String escape(@NonNull String str) {
+    public static String escape(String str) {
         // improved with code from  cybertiger@cyberiantiger.org
         // unicode from him, and defaul for < 32's.
         int sz = str.length();
@@ -1087,8 +1063,7 @@ public class StringUtils {
      * @throws NegativeArraySizeException if <code>repeat &lt; 0</code>
      * @throws NullPointerException       if str is <code>null</code>
      */
-    @NonNull
-    public static String repeat(@NonNull String str, int repeat) {
+    public static String repeat(String str, int repeat) {
         StringBuilder buffer = new StringBuilder(repeat * str.length());
         for (int i = 0; i < repeat; i++) {
             buffer.append(str);
@@ -1106,8 +1081,7 @@ public class StringUtils {
      * @return right padded String
      * @throws NullPointerException if str is <code>null</code>
      */
-    @NonNull
-    public static String rightPad(@NonNull String str, int size) {
+    public static String rightPad(String str, int size) {
         return rightPad(str, size, " ");
     }
 
@@ -1122,8 +1096,7 @@ public class StringUtils {
      * @return right padded String
      * @throws NullPointerException if str or delim is <code>null</code>
      */
-    @NonNull
-    public static String rightPad(@NonNull String str, int size, @NonNull String delim) {
+    public static String rightPad(String str, int size, String delim) {
         if (delim.isEmpty()) {
             return str;
         }
@@ -1144,8 +1117,7 @@ public class StringUtils {
      * @return left padded String
      * @throws NullPointerException if str or delim is <code>null</code>
      */
-    @NonNull
-    public static String leftPad(@NonNull String str, int size) {
+    public static String leftPad(String str, int size) {
         return leftPad(str, size, " ");
     }
 
@@ -1158,8 +1130,7 @@ public class StringUtils {
      * @return left padded String
      * @throws NullPointerException if str or delim is null
      */
-    @NonNull
-    public static String leftPad(@NonNull String str, int size, @NonNull String delim) {
+    public static String leftPad(String str, int size, String delim) {
         if (delim.isEmpty()) {
             return str;
         }
@@ -1194,7 +1165,7 @@ public class StringUtils {
      * @param delim the String to remove at start and end
      * @return the stripped String
      */
-    public static String strip(String str, @Nullable String delim) {
+    public static String strip(String str, String delim) {
         str = stripStart(str, delim);
         return stripEnd(str, delim);
     }
@@ -1218,7 +1189,7 @@ public class StringUtils {
      * @param delimiter the String to remove at start and end
      * @return the stripped Strings
      */
-    public static String[] stripAll(String[] strs, @Nullable String delimiter) {
+    public static String[] stripAll(String[] strs, String delimiter) {
         if ((strs == null) || (strs.length == 0)) {
             return strs;
         }
@@ -1240,7 +1211,7 @@ public class StringUtils {
      * @param strip the String to remove
      * @return the stripped String
      */
-    public static String stripEnd(String str, @Nullable String strip) {
+    public static String stripEnd(String str, String strip) {
         if (str == null) {
             return null;
         }
@@ -1268,7 +1239,7 @@ public class StringUtils {
      * @param strip the String to remove
      * @return the stripped String
      */
-    public static String stripStart(String str, @Nullable String strip) {
+    public static String stripStart(String str, String strip) {
         if (str == null) {
             return null;
         }
@@ -1494,7 +1465,7 @@ public class StringUtils {
      * @return the String that was nested, or <code>null</code>
      * @throws NullPointerException if tag is <code>null</code>
      */
-    public static String getNestedString(String str, @NonNull String tag) {
+    public static String getNestedString(String str, String tag) {
         return getNestedString(str, tag, tag);
     }
 
@@ -1507,7 +1478,7 @@ public class StringUtils {
      * @return the String that was nested, or <code>null</code>
      * @throws NullPointerException if open or close is <code>null</code>
      */
-    public static String getNestedString(String str, @NonNull String open, @NonNull String close) {
+    public static String getNestedString(String str, String open, String close) {
         if (str == null) {
             return null;
         }
@@ -1531,7 +1502,7 @@ public class StringUtils {
      * @return the number of occurrences, 0 if the String is <code>null</code>
      * @throws NullPointerException if sub is <code>null</code>
      */
-    public static int countMatches(@Nullable String str, @NonNull String sub) {
+    public static int countMatches(String str, String sub) {
         if (sub.equals("")) {
             return 0;
         }
@@ -1701,7 +1672,6 @@ public class StringUtils {
      * @deprecated use {@code java.util.Objects.toString()}
      */
     @Deprecated
-    @NonNull
     public static String defaultString(Object obj) {
         return defaultString(obj, "");
     }
@@ -1719,8 +1689,7 @@ public class StringUtils {
      * @deprecated use {@code java.util.Objects.toString()}
      */
     @Deprecated
-    @NonNull
-    public static String defaultString(Object obj, @NonNull String defaultString) {
+    public static String defaultString(Object obj, String defaultString) {
         return (obj == null) ? defaultString : obj.toString();
     }
 
@@ -1753,8 +1722,7 @@ public class StringUtils {
      * @param delimiter the delimiter to use
      * @return the reversed String
      */
-    @NonNull
-    public static String reverseDelimitedString(@NonNull String str, String delimiter) {
+    public static String reverseDelimitedString(String str, String delimiter) {
         // could implement manually, but simple way is to reuse other,
         // probably slower, methods.
         String[] strs = split(str, delimiter);
@@ -1767,7 +1735,7 @@ public class StringUtils {
      *
      * @param array the array to reverse
      */
-    private static void reverseArray(@NonNull String... array) {
+    private static void reverseArray(String... array) {
         int i = 0;
         int j = array.length - 1;
         String tmp;
@@ -1796,8 +1764,7 @@ public class StringUtils {
      * @param maxWidth maximum length of result string
      * @return the abbreviated string
      */
-    @NonNull
-    public static String abbreviate(@NonNull String s, int maxWidth) {
+    public static String abbreviate(String s, int maxWidth) {
         return abbreviate(s, 0, maxWidth);
     }
 
@@ -1816,8 +1783,7 @@ public class StringUtils {
      * @param maxWidth maximum length of result string
      * @return the abbreviated string
      */
-    @NonNull
-    public static String abbreviate(@NonNull String s, int offset, int maxWidth) {
+    public static String abbreviate(String s, int offset, int maxWidth) {
         if (maxWidth < 4) {
             throw new IllegalArgumentException("Minimum abbreviation width is 4");
         }
@@ -1857,7 +1823,7 @@ public class StringUtils {
      * @param s2 the second string
      * @return the portion of s2 where it differs from s1; returns the empty string ("") if they are equal
      */
-    public static String difference(@NonNull String s1, @NonNull String s2) {
+    public static String difference(String s1, String s2) {
         int at = differenceAt(s1, s2);
         if (at == -1) {
             return "";
@@ -1875,7 +1841,7 @@ public class StringUtils {
      * @param s2 the second string
      * @return the index where s2 and s1 begin to differ; -1 if they are equal
      */
-    public static int differenceAt(@NonNull String s1, @NonNull String s2) {
+    public static int differenceAt(String s1, String s2) {
         int i;
         for (i = 0; (i < s1.length()) && (i < s2.length()); ++i) {
             if (s1.charAt(i) != s2.charAt(i)) {
@@ -1897,7 +1863,7 @@ public class StringUtils {
      * @param namespace the namespace which contains the replacements
      * @return the interpolated text
      */
-    public static String interpolate(String text, @NonNull Map<?, ?> namespace) {
+    public static String interpolate(String text, Map<?, ?> namespace) {
         for (Map.Entry<?, ?> entry : namespace.entrySet()) {
             String key = entry.getKey().toString();
 
@@ -1931,8 +1897,7 @@ public class StringUtils {
      * @param replaceThis the things which should be replaced
      * @return humped String
      */
-    @NonNull
-    public static String removeAndHump(@NonNull String data, @NonNull String replaceThis) {
+    public static String removeAndHump(String data, String replaceThis) {
         String temp;
 
         StringBuilder out = new StringBuilder();
@@ -1959,8 +1924,7 @@ public class StringUtils {
      * @throws IndexOutOfBoundsException if data is empty
      * @throws NullPointerException if data is <code>null</code>
      */
-    @NonNull
-    public static String capitalizeFirstLetter(@NonNull String data) {
+    public static String capitalizeFirstLetter(String data) {
         char firstChar = data.charAt(0);
         char titleCase = Character.toTitleCase(firstChar);
         if (firstChar == titleCase) {
@@ -1981,8 +1945,7 @@ public class StringUtils {
      * @throws IndexOutOfBoundsException if data is empty
      * @throws NullPointerException if data is <code>null</code>
      */
-    @NonNull
-    public static String lowercaseFirstLetter(@NonNull String data) {
+    public static String lowercaseFirstLetter(String data) {
         char firstLetter = Character.toLowerCase(data.substring(0, 1).charAt(0));
 
         String restLetters = data.substring(1);
@@ -1997,8 +1960,7 @@ public class StringUtils {
      * @param view the view
      * @return deHumped String
      */
-    @NonNull
-    public static String addAndDeHump(@NonNull String view) {
+    public static String addAndDeHump(String view) {
         StringBuilder sb = new StringBuilder();
 
         for (int i = 0; i < view.length(); i++) {
@@ -2029,7 +1991,7 @@ public class StringUtils {
      * @see #quoteAndEscape(String, char, char[], char[], char, boolean)
      * @see #quoteAndEscape(String, char, char[], char[], char, boolean)
      */
-    public static String quoteAndEscape(@Nullable String source, char quoteChar) {
+    public static String quoteAndEscape(String source, char quoteChar) {
         return quoteAndEscape(source, quoteChar, new char[] {quoteChar}, new char[] {' '}, '\\', false);
     }
 
@@ -2042,7 +2004,7 @@ public class StringUtils {
      * @return the String quoted and escaped
      * @see #quoteAndEscape(String, char, char[], char[], char, boolean)
      */
-    public static String quoteAndEscape(@Nullable String source, char quoteChar, @NonNull char[] quotingTriggers) {
+    public static String quoteAndEscape(String source, char quoteChar, char[] quotingTriggers) {
         return quoteAndEscape(source, quoteChar, new char[] {quoteChar}, quotingTriggers, '\\', false);
     }
 
@@ -2056,11 +2018,7 @@ public class StringUtils {
      * @see #quoteAndEscape(String, char, char[], char[], char, boolean)
      */
     public static String quoteAndEscape(
-            @Nullable String source,
-            char quoteChar,
-            @NonNull final char[] escapedChars,
-            char escapeChar,
-            boolean force) {
+            String source, char quoteChar, final char[] escapedChars, char escapeChar, boolean force) {
         return quoteAndEscape(source, quoteChar, escapedChars, new char[] {' '}, escapeChar, force);
     }
 
@@ -2074,10 +2032,10 @@ public class StringUtils {
      * @return the String quoted and escaped
      */
     public static String quoteAndEscape(
-            @Nullable String source,
+            String source,
             char quoteChar,
-            @NonNull final char[] escapedChars,
-            @NonNull final char[] quotingTriggers,
+            final char[] escapedChars,
+            final char[] quotingTriggers,
             char escapeChar,
             boolean force) {
         if (source == null) {
@@ -2119,7 +2077,7 @@ public class StringUtils {
      * @param escapeChar prefix for escaping a character
      * @return the String escaped
      */
-    public static String escape(@Nullable String source, @NonNull final char[] escapedChars, char escapeChar) {
+    public static String escape(String source, final char[] escapedChars, char escapeChar) {
         if (source == null) {
             return null;
         }
@@ -2149,8 +2107,7 @@ public class StringUtils {
      * @param s a not null String
      * @return a string with unique whitespace
      */
-    @NonNull
-    public static String removeDuplicateWhitespace(@NonNull String s) {
+    public static String removeDuplicateWhitespace(String s) {
         StringBuilder result = new StringBuilder();
         int length = s.length();
         boolean isPreviousWhiteSpace = false;
@@ -2178,7 +2135,7 @@ public class StringUtils {
      *     {@code StringUtils.unifyLineSeparators(s)} to simply {@code s}.
      */
     @Deprecated
-    public static String unifyLineSeparators(@Nullable String s) {
+    public static String unifyLineSeparators(String s) {
         return unifyLineSeparators(s, System.lineSeparator());
     }
 
@@ -2191,7 +2148,7 @@ public class StringUtils {
      * @return a String that contains only System line separators
      * @throws IllegalArgumentException if ls is not "\n", "\r", or "\r\n"
      */
-    public static String unifyLineSeparators(@Nullable String s, @Nullable String ls) {
+    public static String unifyLineSeparators(String s, String ls) {
         if (s == null) {
             return null;
         }
@@ -2246,7 +2203,7 @@ public class StringUtils {
      *             <code>null</code>, where this method returns <code>false</code>.
      */
     @Deprecated
-    public static boolean contains(@Nullable String str, char searchChar) {
+    public static boolean contains(String str, char searchChar) {
         return !isEmpty(str) && str.indexOf(searchChar) >= 0;
     }
 
@@ -2274,7 +2231,7 @@ public class StringUtils {
      *             returns <code>false</code>.
      */
     @Deprecated
-    public static boolean contains(@Nullable String str, @Nullable String searchStr) {
+    public static boolean contains(String str, String searchStr) {
         return !(str == null || searchStr == null) && str.contains(searchStr);
     }
 
@@ -2296,7 +2253,7 @@ public class StringUtils {
      * @return true if the String ends with the search String,
      *         false if not or <code>null</code> string input
      */
-    public static boolean endsWithIgnoreCase(@Nullable String str, @Nullable String searchStr) {
+    public static boolean endsWithIgnoreCase(String str, String searchStr) {
         if (str == null || searchStr == null) {
             // for consistency with contains
             return false;

--- a/src/main/java/org/apache/maven/shared/utils/WriterFactory.java
+++ b/src/main/java/org/apache/maven/shared/utils/WriterFactory.java
@@ -30,7 +30,6 @@ import java.io.Writer;
 import java.nio.charset.Charset;
 
 import org.apache.maven.shared.utils.xml.XmlStreamWriter;
-import org.jspecify.annotations.NonNull;
 
 /**
  * Utility to create Writers, with explicit encoding choice: platform default,
@@ -115,7 +114,7 @@ public class WriterFactory {
      * @deprecated use {@code org.apache.commons.io.output.XmlStreamWriter} instead
      */
     @Deprecated
-    public static XmlStreamWriter newXmlWriter(@NonNull OutputStream out) throws IOException {
+    public static XmlStreamWriter newXmlWriter(OutputStream out) throws IOException {
         return new XmlStreamWriter(out);
     }
 
@@ -129,7 +128,7 @@ public class WriterFactory {
      * @deprecated use {@code org.apache.commons.io.output.XmlStreamWriter} instead
      */
     @Deprecated
-    public static XmlStreamWriter newXmlWriter(@NonNull File file) throws IOException {
+    public static XmlStreamWriter newXmlWriter(File file) throws IOException {
         return new XmlStreamWriter(file);
     }
 
@@ -141,7 +140,7 @@ public class WriterFactory {
      * @deprecated always specify an encoding. Do not depend on the default platform character set.
      */
     @Deprecated
-    public static Writer newPlatformWriter(@NonNull OutputStream out) {
+    public static Writer newPlatformWriter(OutputStream out) {
         return new OutputStreamWriter(out);
     }
 
@@ -154,7 +153,7 @@ public class WriterFactory {
      * @deprecated always specify an encoding. Do not depend on the default platform character set.
      */
     @Deprecated
-    public static Writer newPlatformWriter(@NonNull File file) throws IOException {
+    public static Writer newPlatformWriter(File file) throws IOException {
         return new FileWriter(file);
     }
 
@@ -171,8 +170,7 @@ public class WriterFactory {
      * @deprecated use {@code new OutputStreamWriter(out, encoding)} instead
      */
     @Deprecated
-    public static Writer newWriter(@NonNull OutputStream out, @NonNull String encoding)
-            throws UnsupportedEncodingException {
+    public static Writer newWriter(OutputStream out, String encoding) throws UnsupportedEncodingException {
         return new OutputStreamWriter(out, encoding);
     }
 
@@ -190,7 +188,7 @@ public class WriterFactory {
      * @deprecated use {@code java.nio.file.Files.newBufferedWriter()} instead
      */
     @Deprecated
-    public static Writer newWriter(@NonNull File file, @NonNull String encoding)
+    public static Writer newWriter(File file, String encoding)
             throws UnsupportedEncodingException, FileNotFoundException {
         return newWriter(new FileOutputStream(file), encoding);
     }

--- a/src/main/java/org/apache/maven/shared/utils/cli/CommandLineUtils.java
+++ b/src/main/java/org/apache/maven/shared/utils/cli/CommandLineUtils.java
@@ -31,8 +31,6 @@ import java.util.concurrent.TimeUnit;
 
 import org.apache.maven.shared.utils.Os;
 import org.apache.maven.shared.utils.StringUtils;
-import org.jspecify.annotations.NonNull;
-import org.jspecify.annotations.Nullable;
 
 /**
  * @author <a href="mailto:trygvis@inamo.no">Trygve Laugst&oslash;l </a>
@@ -80,7 +78,7 @@ public abstract class CommandLineUtils {
      * @return code
      * @throws CommandLineException in case of a problem
      */
-    public static int executeCommandLine(@NonNull Commandline cl, StreamConsumer systemOut, StreamConsumer systemErr)
+    public static int executeCommandLine(Commandline cl, StreamConsumer systemOut, StreamConsumer systemErr)
             throws CommandLineException {
         return executeCommandLine(cl, null, systemOut, systemErr, 0);
     }
@@ -94,7 +92,7 @@ public abstract class CommandLineUtils {
      * @throws CommandLineException in case of a problem
      */
     public static int executeCommandLine(
-            @NonNull Commandline cl, StreamConsumer systemOut, StreamConsumer systemErr, int timeoutInSeconds)
+            Commandline cl, StreamConsumer systemOut, StreamConsumer systemErr, int timeoutInSeconds)
             throws CommandLineException {
         return executeCommandLine(cl, null, systemOut, systemErr, timeoutInSeconds);
     }
@@ -108,7 +106,7 @@ public abstract class CommandLineUtils {
      * @throws CommandLineException in case of a problem
      */
     public static int executeCommandLine(
-            @NonNull Commandline cl, InputStream systemIn, StreamConsumer systemOut, StreamConsumer systemErr)
+            Commandline cl, InputStream systemIn, StreamConsumer systemOut, StreamConsumer systemErr)
             throws CommandLineException {
         return executeCommandLine(cl, systemIn, systemOut, systemErr, 0);
     }
@@ -123,7 +121,7 @@ public abstract class CommandLineUtils {
      * @throws CommandLineException or CommandLineTimeOutException if time out occurs
      */
     public static int executeCommandLine(
-            @NonNull Commandline cl,
+            Commandline cl,
             InputStream systemIn,
             StreamConsumer systemOut,
             StreamConsumer systemErr,
@@ -144,12 +142,12 @@ public abstract class CommandLineUtils {
      * @throws CommandLineException or CommandLineTimeOutException if time out occurs
      */
     public static int executeCommandLine(
-            @NonNull Commandline cl,
+            Commandline cl,
             InputStream systemIn,
             StreamConsumer systemOut,
             StreamConsumer systemErr,
             int timeoutInSeconds,
-            @Nullable Runnable runAfterProcessTermination)
+            Runnable runAfterProcessTermination)
             throws CommandLineException {
         return executeCommandLine(
                 cl, systemIn, systemOut, systemErr, timeoutInSeconds, runAfterProcessTermination, null);
@@ -168,13 +166,13 @@ public abstract class CommandLineUtils {
      * @throws CommandLineException or CommandLineTimeOutException if time out occurs
      */
     public static int executeCommandLine(
-            @NonNull Commandline cl,
+            Commandline cl,
             InputStream systemIn,
             StreamConsumer systemOut,
             StreamConsumer systemErr,
             int timeoutInSeconds,
-            @Nullable Runnable runAfterProcessTermination,
-            @Nullable final Charset streamCharset)
+            Runnable runAfterProcessTermination,
+            final Charset streamCharset)
             throws CommandLineException {
         final CommandLineCallable future = executeCommandLineAsCallable(
                 cl, systemIn, systemOut, systemErr, timeoutInSeconds, runAfterProcessTermination, streamCharset);
@@ -196,12 +194,12 @@ public abstract class CommandLineUtils {
      * @throws CommandLineException or CommandLineTimeOutException if time out occurs
      */
     public static CommandLineCallable executeCommandLineAsCallable(
-            @NonNull final Commandline cl,
-            @Nullable final InputStream systemIn,
+            final Commandline cl,
+            final InputStream systemIn,
             final StreamConsumer systemOut,
             final StreamConsumer systemErr,
             final int timeoutInSeconds,
-            @Nullable final Runnable runAfterProcessTermination)
+            final Runnable runAfterProcessTermination)
             throws CommandLineException {
         return executeCommandLineAsCallable(
                 cl, systemIn, systemOut, systemErr, timeoutInSeconds, runAfterProcessTermination, null);
@@ -223,13 +221,13 @@ public abstract class CommandLineUtils {
      * @throws CommandLineException or CommandLineTimeOutException if time out occurs
      */
     public static CommandLineCallable executeCommandLineAsCallable(
-            @NonNull final Commandline cl,
-            @Nullable final InputStream systemIn,
+            final Commandline cl,
+            final InputStream systemIn,
             final StreamConsumer systemOut,
             final StreamConsumer systemErr,
             final int timeoutInSeconds,
-            @Nullable final Runnable runAfterProcessTermination,
-            @Nullable final Charset streamCharset)
+            final Runnable runAfterProcessTermination,
+            final Charset streamCharset)
             throws CommandLineException {
         //noinspection ConstantConditions
         if (cl == null) {

--- a/src/main/java/org/apache/maven/shared/utils/cli/StreamPumper.java
+++ b/src/main/java/org/apache/maven/shared/utils/cli/StreamPumper.java
@@ -25,8 +25,6 @@ import java.io.InputStreamReader;
 import java.io.Reader;
 import java.nio.charset.Charset;
 
-import org.jspecify.annotations.Nullable;
-
 /**
  * Class to pump the error stream during Process's runtime. Copied from the Ant built-in task.
  *
@@ -55,7 +53,7 @@ public class StreamPumper extends AbstractStreamHandler {
      * @param consumer {@link StreamConsumer}
      * @param charset {@link Charset}
      */
-    public StreamPumper(InputStream in, StreamConsumer consumer, @Nullable Charset charset) {
+    public StreamPumper(InputStream in, StreamConsumer consumer, Charset charset) {
         this(null == charset ? new InputStreamReader(in) : new InputStreamReader(in, charset), consumer);
     }
 

--- a/src/main/java/org/apache/maven/shared/utils/introspection/ReflectionValueExtractor.java
+++ b/src/main/java/org/apache/maven/shared/utils/introspection/ReflectionValueExtractor.java
@@ -27,8 +27,6 @@ import java.util.WeakHashMap;
 
 import org.apache.maven.shared.utils.StringUtils;
 import org.apache.maven.shared.utils.introspection.MethodMap.AmbiguousException;
-import org.jspecify.annotations.NonNull;
-import org.jspecify.annotations.Nullable;
 
 /**
  * <p>Using simple dotted expressions to extract the values from an Object instance,
@@ -139,7 +137,7 @@ public class ReflectionValueExtractor {
      * @return the object defined by the expression
      * @throws IntrospectionException if any
      */
-    public static Object evaluate(@NonNull String expression, @Nullable Object root) throws IntrospectionException {
+    public static Object evaluate(String expression, Object root) throws IntrospectionException {
         return evaluate(expression, root, true);
     }
 
@@ -161,8 +159,7 @@ public class ReflectionValueExtractor {
      * @return the object defined by the expression
      * @throws IntrospectionException if any
      */
-    public static Object evaluate(@NonNull String expression, @Nullable Object root, boolean trimRootToken)
-            throws IntrospectionException {
+    public static Object evaluate(String expression, Object root, boolean trimRootToken) throws IntrospectionException {
         Object value = root;
 
         // ----------------------------------------------------------------------

--- a/src/main/java/org/apache/maven/shared/utils/io/DirectoryScanner.java
+++ b/src/main/java/org/apache/maven/shared/utils/io/DirectoryScanner.java
@@ -26,9 +26,6 @@ import java.util.HashSet;
 import java.util.List;
 import java.util.Set;
 
-import org.jspecify.annotations.NonNull;
-import org.jspecify.annotations.Nullable;
-
 /**
  * <p>Class for scanning a directory for files/directories which match certain criteria.</p>
  * <p>
@@ -277,7 +274,7 @@ public class DirectoryScanner {
      *
      * @param basedir the base directory for scanning. Should not be <code>null</code>.
      */
-    public void setBasedir(@NonNull final File basedir) {
+    public void setBasedir(final File basedir) {
         this.basedir = basedir;
     }
 
@@ -460,7 +457,7 @@ public class DirectoryScanner {
      * @param newFiles array of new files
      * @return calculated difference
      */
-    public static DirectoryScanResult diffFiles(@Nullable String[] oldFiles, @Nullable String[] newFiles) {
+    public static DirectoryScanResult diffFiles(String[] oldFiles, String[] newFiles) {
         Set<String> oldFileSet = arrayAsHashSet(oldFiles);
         Set<String> newFileSet = arrayAsHashSet(newFiles);
 
@@ -492,7 +489,7 @@ public class DirectoryScanner {
      * @param array  the array
      * @return the filled HashSet of type T
      */
-    private static <T> Set<T> arrayAsHashSet(@Nullable T[] array) {
+    private static <T> Set<T> arrayAsHashSet(T[] array) {
         if (array == null || array.length == 0) {
             return Collections.emptySet();
         }
@@ -551,7 +548,7 @@ public class DirectoryScanner {
      * @see #dirsExcluded
      * @see #slowScan
      */
-    private void scandir(@NonNull final File dir, @NonNull final String vpath, final boolean fast) {
+    private void scandir(final File dir, final String vpath, final boolean fast) {
         String[] newfiles = dir.list();
 
         if (newfiles == null) {
@@ -696,7 +693,7 @@ public class DirectoryScanner {
      * @return <code>true</code> when the name matches against the start of at least one include pattern, or
      *         <code>false</code> otherwise
      */
-    private boolean couldHoldIncluded(@NonNull final String name) {
+    private boolean couldHoldIncluded(final String name) {
         return includesPatterns.matchesPatternStart(name, isCaseSensitive);
     }
 
@@ -707,7 +704,7 @@ public class DirectoryScanner {
      * @return <code>true</code> when the name matches against at least one exclude pattern, or <code>false</code>
      *         otherwise
      */
-    private boolean isExcluded(@NonNull final String name) {
+    private boolean isExcluded(final String name) {
         return excludesPatterns.matches(name, isCaseSensitive);
     }
 

--- a/src/main/java/org/apache/maven/shared/utils/io/FileUtils.java
+++ b/src/main/java/org/apache/maven/shared/utils/io/FileUtils.java
@@ -51,8 +51,6 @@ import java.util.Random;
 import org.apache.commons.io.IOUtils;
 import org.apache.maven.shared.utils.Os;
 import org.apache.maven.shared.utils.StringUtils;
-import org.jspecify.annotations.NonNull;
-import org.jspecify.annotations.Nullable;
 
 /**
  * This class provides basic facilities for manipulating files and file paths.
@@ -129,7 +127,6 @@ public class FileUtils {
      * @return the default excludes pattern
      * @see DirectoryScanner#DEFAULTEXCLUDES
      */
-    @NonNull
     public static String[] getDefaultExcludes() {
         return DirectoryScanner.DEFAULTEXCLUDES;
     }
@@ -138,7 +135,6 @@ public class FileUtils {
      * @return the default excludes pattern as list
      * @see #getDefaultExcludes()
      */
-    @NonNull
     public static List<String> getDefaultExcludesAsList() {
         return Arrays.asList(getDefaultExcludes());
     }
@@ -148,7 +144,6 @@ public class FileUtils {
      * @see DirectoryScanner#DEFAULTEXCLUDES
      * @see StringUtils#join(Object[], String)
      */
-    @NonNull
     public static String getDefaultExcludesAsString() {
         return StringUtils.join(DirectoryScanner.DEFAULTEXCLUDES, ",");
     }
@@ -162,8 +157,7 @@ public class FileUtils {
      * @deprecated use {@code Paths.get(path).getParent().getName()}
      */
     @Deprecated
-    @NonNull
-    public static String dirname(@NonNull String path) {
+    public static String dirname(String path) {
         int i = path.lastIndexOf(File.separator);
         return (i >= 0 ? path.substring(0, i) : "");
     }
@@ -176,8 +170,7 @@ public class FileUtils {
      * @deprecated use {@code Paths.get(path).getName()}
      */
     @Deprecated
-    @NonNull
-    public static String filename(@NonNull String path) {
+    public static String filename(String path) {
         int i = path.lastIndexOf(File.separator);
         return (i >= 0 ? path.substring(i + 1) : path);
     }
@@ -191,8 +184,7 @@ public class FileUtils {
      * @deprecated use {@code org.apache.commons.io.FilenameUtils.getExtension}
      */
     @Deprecated
-    @NonNull
-    public static String extension(@NonNull String path) {
+    public static String extension(String path) {
         // Ensure the last dot is after the last file separator
         int lastSep = path.lastIndexOf(File.separatorChar);
         int lastDot;
@@ -220,7 +212,7 @@ public class FileUtils {
      * @deprecated use {@code java.io.File.exists()}
      */
     @Deprecated
-    public static boolean fileExists(@NonNull String fileName) {
+    public static boolean fileExists(String fileName) {
         File file = new File(fileName);
         return file.exists();
     }
@@ -234,8 +226,7 @@ public class FileUtils {
      * @deprecated use {@code new String(java.nio.file.Files.readAllBytes(file))}
      */
     @Deprecated
-    @NonNull
-    public static String fileRead(@NonNull String file) throws IOException {
+    public static String fileRead(String file) throws IOException {
         return fileRead(file, null);
     }
 
@@ -247,8 +238,7 @@ public class FileUtils {
      * @deprecated use {@code new String(java.nio.file.Files.readAllBytes(Paths.get(file)), encoding)}
      */
     @Deprecated
-    @NonNull
-    private static String fileRead(@NonNull String file, @Nullable String encoding) throws IOException {
+    private static String fileRead(String file, String encoding) throws IOException {
         return fileRead(new File(file), encoding);
     }
 
@@ -261,8 +251,7 @@ public class FileUtils {
      * @deprecated use {@code new String(java.nio.file.Files.readAllBytes(file.toPath()))}
      */
     @Deprecated
-    @NonNull
-    public static String fileRead(@NonNull File file) throws IOException {
+    public static String fileRead(File file) throws IOException {
         return fileRead(file, null);
     }
 
@@ -274,8 +263,7 @@ public class FileUtils {
      * @deprecated use {@code new String(java.nio.file.Files.readAllBytes(file.toPath()), encoding)}
      */
     @Deprecated
-    @NonNull
-    public static String fileRead(@NonNull File file, @Nullable String encoding) throws IOException {
+    public static String fileRead(File file, String encoding) throws IOException {
         Charset charset = charset(encoding);
 
         StringBuilder buf = new StringBuilder();
@@ -300,8 +288,7 @@ public class FileUtils {
      * @deprecated use {@code java.nio.file.Files.readAllLines()}
      */
     @Deprecated
-    @NonNull
-    public static String[] fileReadArray(@NonNull File file) throws IOException {
+    public static String[] fileReadArray(File file) throws IOException {
         List<String> lines = loadFile(file);
 
         return lines.toArray(new String[lines.size()]);
@@ -318,7 +305,7 @@ public class FileUtils {
      *     StandardOpenOption.APPEND, StandardOpenOption.CREATE)}
      */
     @Deprecated
-    public static void fileAppend(@NonNull String fileName, @NonNull String data) throws IOException {
+    public static void fileAppend(String fileName, String data) throws IOException {
         fileAppend(fileName, null, data);
     }
 
@@ -333,8 +320,7 @@ public class FileUtils {
      *     StandardOpenOption.APPEND, StandardOpenOption.CREATE)}
      */
     @Deprecated
-    public static void fileAppend(@NonNull String fileName, @Nullable String encoding, @NonNull String data)
-            throws IOException {
+    public static void fileAppend(String fileName, String encoding, String data) throws IOException {
         Charset charset = charset(encoding);
 
         try (OutputStream out = new FileOutputStream(fileName, true)) {
@@ -353,7 +339,7 @@ public class FileUtils {
      *     data.getBytes(), StandardOpenOption.CREATE)}
      */
     @Deprecated
-    public static void fileWrite(@NonNull String fileName, @NonNull String data) throws IOException {
+    public static void fileWrite(String fileName, String data) throws IOException {
         fileWrite(fileName, null, data);
     }
 
@@ -368,8 +354,7 @@ public class FileUtils {
      *     data.getBytes(encoding), StandardOpenOption.CREATE)}
      */
     @Deprecated
-    public static void fileWrite(@NonNull String fileName, @Nullable String encoding, @NonNull String data)
-            throws IOException {
+    public static void fileWrite(String fileName, String encoding, String data) throws IOException {
         File file = new File(fileName);
         fileWrite(file, encoding, data);
     }
@@ -385,8 +370,7 @@ public class FileUtils {
      *     data.getBytes(encoding), StandardOpenOption.CREATE)}
      */
     @Deprecated
-    public static void fileWrite(@NonNull File file, @Nullable String encoding, @NonNull String data)
-            throws IOException {
+    public static void fileWrite(File file, String encoding, String data) throws IOException {
         Charset charset = charset(encoding);
 
         try (Writer writer = Files.newBufferedWriter(file.toPath(), charset)) {
@@ -405,7 +389,7 @@ public class FileUtils {
      *     data.getBytes(encoding), StandardOpenOption.CREATE)}
      */
     @Deprecated
-    public static void fileWriteArray(@NonNull File file, @Nullable String... data) throws IOException {
+    public static void fileWriteArray(File file, String... data) throws IOException {
         fileWriteArray(file, null, data);
     }
 
@@ -420,8 +404,7 @@ public class FileUtils {
      *     data.getBytes(encoding), StandardOpenOption.CREATE)}
      */
     @Deprecated
-    public static void fileWriteArray(@NonNull File file, @Nullable String encoding, @Nullable String... data)
-            throws IOException {
+    public static void fileWriteArray(File file, String encoding, String... data) throws IOException {
         Charset charset = charset(encoding);
 
         try (Writer writer = Files.newBufferedWriter(file.toPath(), charset)) {
@@ -439,7 +422,7 @@ public class FileUtils {
      * @deprecated use {@code Files.delete(Paths.get(fileName))}
      */
     @Deprecated
-    public static void fileDelete(@NonNull String fileName) {
+    public static void fileDelete(String fileName) {
         File file = new File(fileName);
         deleteLegacyStyle(file);
     }
@@ -453,7 +436,7 @@ public class FileUtils {
      * @param extensions an array of expected extensions
      * @return an array of files for the wanted extensions
      */
-    public static String[] getFilesFromExtension(@NonNull String directory, @NonNull String... extensions) {
+    public static String[] getFilesFromExtension(String directory, String... extensions) {
         List<String> files = new ArrayList<>();
 
         File currentDir = new File(directory);
@@ -499,8 +482,7 @@ public class FileUtils {
     /**
      * Private helper method for getFilesFromExtension()
      */
-    @NonNull
-    private static List<String> blendFilesToList(@NonNull List<String> v, @NonNull String... files) {
+    private static List<String> blendFilesToList(List<String> v, String... files) {
         Collections.addAll(v, files);
 
         return v;
@@ -511,7 +493,7 @@ public class FileUtils {
      * Note that if the file does not have an extension, an empty string
      * (&quot;&quot;) is matched for.
      */
-    private static boolean isValidFile(@NonNull String file, @NonNull String... extensions) {
+    private static boolean isValidFile(String file, String... extensions) {
         String extension = extension(file);
 
         // ok.. now that we have the "extension" go through the current know
@@ -535,7 +517,7 @@ public class FileUtils {
      * @deprecated use {@code java.nio.file.Files.createDirectories(Paths.get(dir))}
      */
     @Deprecated
-    public static void mkdir(@NonNull String dir) {
+    public static void mkdir(String dir) {
         File file = new File(dir);
 
         if (Os.isFamily(Os.FAMILY_WINDOWS) && !isValidWindowsFileName(file)) {
@@ -560,7 +542,7 @@ public class FileUtils {
      * @deprecated use {@code org.apache.commons.io.FileUtils.contentEquals()}
      */
     @Deprecated
-    public static boolean contentEquals(@NonNull final File file1, @NonNull final File file2) throws IOException {
+    public static boolean contentEquals(final File file1, final File file2) throws IOException {
         final boolean file1Exists = file1.exists();
         if (file1Exists != file2.exists()) {
             return false;
@@ -589,8 +571,7 @@ public class FileUtils {
      * @return the equivalent <code>File</code> object, or <code>null</code> if the URL's protocol
      *     is not <code>file</code>
      */
-    @Nullable
-    public static File toFile(@Nullable final URL url) {
+    public static File toFile(final URL url) {
         if (url == null || !url.getProtocol().equalsIgnoreCase("file")) {
             return null;
         }
@@ -614,8 +595,7 @@ public class FileUtils {
      * @return the array of URLs
      * @throws IOException if an error occurs
      */
-    @NonNull
-    public static URL[] toURLs(@NonNull final File... files) throws IOException {
+    public static URL[] toURLs(final File... files) throws IOException {
         final URL[] urls = new URL[files.length];
 
         for (int i = 0; i < urls.length; i++) {
@@ -638,8 +618,7 @@ public class FileUtils {
      * @deprecated use {@code org.apache.commons.io.FilenameUtils.removeExtension()}
      */
     @Deprecated
-    @NonNull
-    public static String removeExtension(@NonNull final String filename) {
+    public static String removeExtension(final String filename) {
         String ext = extension(filename);
 
         if ("".equals(ext)) {
@@ -664,8 +643,7 @@ public class FileUtils {
      * @deprecated use {@code org.apache.commons.io.FilenameUtils.getExtension()}
      */
     @Deprecated
-    @NonNull
-    public static String getExtension(@NonNull final String filename) {
+    public static String getExtension(final String filename) {
         return extension(filename);
     }
 
@@ -684,8 +662,7 @@ public class FileUtils {
      * @deprecated use {@code org.apache.commons.io.FileUtils.copyFileToDirectory()}
      */
     @Deprecated
-    public static void copyFileToDirectory(@NonNull final File source, @NonNull final File destinationDirectory)
-            throws IOException {
+    public static void copyFileToDirectory(final File source, final File destinationDirectory) throws IOException {
         if (destinationDirectory.exists() && !destinationDirectory.isDirectory()) {
             throw new IOException("Destination is not a directory");
         }
@@ -707,8 +684,8 @@ public class FileUtils {
      *                                       occurs during copying
      * @throws java.io.FileNotFoundException if <code>source</code> isn't a normal file
      */
-    private static void copyFileToDirectoryIfModified(
-            @NonNull final File source, @NonNull final File destinationDirectory) throws IOException {
+    private static void copyFileToDirectoryIfModified(final File source, final File destinationDirectory)
+            throws IOException {
         if (destinationDirectory.exists() && !destinationDirectory.isDirectory()) {
             throw new IllegalArgumentException("Destination is not a directory");
         }
@@ -731,7 +708,7 @@ public class FileUtils {
      *     StandardCopyOption.REPLACE_EXISTING)}
      */
     @Deprecated
-    public static void copyFile(@NonNull final File source, @NonNull final File destination) throws IOException {
+    public static void copyFile(final File source, final File destination) throws IOException {
         // check source exists
         if (!source.exists()) {
             final String message = "File " + source + " does not exist";
@@ -759,7 +736,7 @@ public class FileUtils {
         }
     }
 
-    private static void mkdirsFor(@NonNull File destination) {
+    private static void mkdirsFor(File destination) {
         // does destination directory exist ?
         if (destination.getParentFile() != null && !destination.getParentFile().exists()) {
             //noinspection ResultOfMethodCallIgnored
@@ -767,7 +744,7 @@ public class FileUtils {
         }
     }
 
-    private static void doCopyFile(@NonNull File source, @NonNull File destination) throws IOException {
+    private static void doCopyFile(File source, File destination) throws IOException {
 
         try (FileInputStream fis = new FileInputStream(source);
                 FileOutputStream fos = new FileOutputStream(destination);
@@ -798,8 +775,7 @@ public class FileUtils {
      * @throws IOException if <code>source</code> does not exist, <code>destination</code> cannot be
      *                     written to, or an IO error occurs during copying
      */
-    private static boolean copyFileIfModified(@NonNull final File source, @NonNull final File destination)
-            throws IOException {
+    private static boolean copyFileIfModified(final File source, final File destination) throws IOException {
         if (destination.lastModified() < source.lastModified()) {
             copyFile(source, destination);
 
@@ -826,7 +802,7 @@ public class FileUtils {
      * @deprecated use {@code java.nio.file.Files.copy(source.openStream(), destination.toPath(),
      *     StandardCopyOption.REPLACE_EXISTING)}
      */
-    public static void copyURLToFile(@NonNull final URL source, @NonNull final File destination) throws IOException {
+    public static void copyURLToFile(final URL source, final File destination) throws IOException {
         copyStreamToFile(source.openStream(), destination);
     }
 
@@ -849,8 +825,7 @@ public class FileUtils {
      *     StandardCopyOption.REPLACE_EXISTING)}
      */
     @Deprecated
-    private static void copyStreamToFile(@NonNull final InputStream source, @NonNull final File destination)
-            throws IOException {
+    private static void copyStreamToFile(final InputStream source, final File destination) throws IOException {
         // does destination directory exist ?
         if (destination.getParentFile() != null && !destination.getParentFile().exists()) {
             // noinspection ResultOfMethodCallIgnored
@@ -889,8 +864,7 @@ public class FileUtils {
      * @deprecated use {@code org.apache.commons.io.FilenameUtils.normalize()}
      */
     @Deprecated
-    @NonNull
-    public static String normalize(@NonNull final String path) {
+    public static String normalize(final String path) {
         String normalized = path;
         // Resolve occurrences of "//" in the normalized path
         while (true) {
@@ -936,8 +910,7 @@ public class FileUtils {
      * @param filename absolute or relative file path to resolve
      * @return the canonical <code>File</code> of <code>filename</code>
      */
-    @NonNull
-    public static File resolveFile(final File baseFile, @NonNull String filename) {
+    public static File resolveFile(final File baseFile, String filename) {
         String filenm = filename;
         if ('/' != File.separatorChar) {
             filenm = filename.replace('/', File.separatorChar);
@@ -1003,7 +976,7 @@ public class FileUtils {
      * @deprecated use {@code org.apache.commons.io.FileUtils.deleteQuietly()}
      */
     @Deprecated
-    public static void forceDelete(@NonNull final String file) throws IOException {
+    public static void forceDelete(final String file) throws IOException {
         forceDelete(new File(file));
     }
 
@@ -1015,7 +988,7 @@ public class FileUtils {
      * @deprecated use {@code org.apache.commons.io.FileUtils.deleteQuietly()}
      */
     @Deprecated
-    public static void forceDelete(@NonNull final File file) throws IOException {
+    public static void forceDelete(final File file) throws IOException {
         if (file.isDirectory()) {
             deleteDirectory(file);
         } else {
@@ -1039,7 +1012,7 @@ public class FileUtils {
      * @deprecated use {@code java.nio.file.Files.delete(file.toPath())}
      */
     @Deprecated
-    public static void delete(@NonNull File file) throws IOException {
+    public static void delete(File file) throws IOException {
         Files.delete(file.toPath());
     }
 
@@ -1049,7 +1022,7 @@ public class FileUtils {
      * @deprecated use {@code java.nio.file.Files.delete(file.toPath())}
      */
     @Deprecated
-    public static boolean deleteLegacyStyle(@NonNull File file) {
+    public static boolean deleteLegacyStyle(File file) {
         try {
             Files.delete(file.toPath());
             return true;
@@ -1066,7 +1039,7 @@ public class FileUtils {
      * @param file a file
      * @throws IOException if any
      */
-    private static boolean deleteFile(@NonNull File file) throws IOException {
+    private static boolean deleteFile(File file) throws IOException {
         if (file.isDirectory()) {
             throw new IOException("File " + file + " isn't a file.");
         }
@@ -1097,7 +1070,7 @@ public class FileUtils {
      * @deprecated use {@code org.apache.commons.io.FileUtils.forceMkdir()}
      */
     @Deprecated
-    public static void forceMkdir(@NonNull final File file) throws IOException {
+    public static void forceMkdir(final File file) throws IOException {
         if (Os.isFamily(Os.FAMILY_WINDOWS) && !isValidWindowsFileName(file)) {
             throw new IllegalArgumentException(
                     "The file (" + file.getAbsolutePath() + ") cannot contain any of the following characters: \n"
@@ -1126,7 +1099,7 @@ public class FileUtils {
      * @deprecated use {@code org.apache.commons.io.FileUtils.deleteDirectory()}
      */
     @Deprecated
-    public static void deleteDirectory(@NonNull final String directory) throws IOException {
+    public static void deleteDirectory(final String directory) throws IOException {
         deleteDirectory(new File(directory));
     }
 
@@ -1138,7 +1111,7 @@ public class FileUtils {
      * @deprecated use {@code org.apache.commons.io.FileUtils.deleteDirectory()}
      */
     @Deprecated
-    public static void deleteDirectory(@NonNull final File directory) throws IOException {
+    public static void deleteDirectory(final File directory) throws IOException {
         if (!directory.exists()) {
             return;
         }
@@ -1166,7 +1139,7 @@ public class FileUtils {
      * @deprecated use {@code org.apache.commons.io.FileUtils.cleanDirectory()}
      */
     @Deprecated
-    public static void cleanDirectory(@NonNull final File directory) throws IOException {
+    public static void cleanDirectory(final File directory) throws IOException {
         if (!directory.exists()) {
             final String message = directory + " does not exist";
             throw new IllegalArgumentException(message);
@@ -1206,7 +1179,7 @@ public class FileUtils {
      * @deprecated use {@code org.apache.commons.io.FileUtils.sizeOf()}
      */
     @Deprecated
-    public static long sizeOfDirectory(@NonNull final String directory) {
+    public static long sizeOfDirectory(final String directory) {
         return sizeOfDirectory(new File(directory));
     }
 
@@ -1218,7 +1191,7 @@ public class FileUtils {
      * @deprecated use {@code org.apache.commons.io.FileUtils.sizeOf()}
      */
     @Deprecated
-    public static long sizeOfDirectory(@NonNull final File directory) {
+    public static long sizeOfDirectory(final File directory) {
         if (!directory.exists()) {
             final String message = directory + " does not exist";
             throw new IllegalArgumentException(message);
@@ -1260,9 +1233,7 @@ public class FileUtils {
      * @throws IOException never
      * @see #getFileNames(File, String, String, boolean)
      */
-    @NonNull
-    public static List<File> getFiles(@NonNull File directory, @Nullable String includes, @Nullable String excludes)
-            throws IOException {
+    public static List<File> getFiles(File directory, String includes, String excludes) throws IOException {
         return getFiles(directory, includes, excludes, true);
     }
 
@@ -1281,9 +1252,7 @@ public class FileUtils {
      * @throws IOException never
      * @see #getFileNames(File, String, String, boolean)
      */
-    @NonNull
-    public static List<File> getFiles(
-            @NonNull File directory, @Nullable String includes, @Nullable String excludes, boolean includeBasedir)
+    public static List<File> getFiles(File directory, String includes, String excludes, boolean includeBasedir)
             throws IOException {
         List<String> fileNames = getFileNames(directory, includes, excludes, includeBasedir);
 
@@ -1309,9 +1278,7 @@ public class FileUtils {
      * @return a list of file names
      * @throws IOException never
      */
-    @NonNull
-    public static List<String> getFileNames(
-            @NonNull File directory, @Nullable String includes, @Nullable String excludes, boolean includeBasedir)
+    public static List<String> getFileNames(File directory, String includes, String excludes, boolean includeBasedir)
             throws IOException {
         return getFileNames(directory, includes, excludes, includeBasedir, true);
     }
@@ -1329,13 +1296,8 @@ public class FileUtils {
      * @param includeBasedir  true to include the base directory at the start of each path
      * @return a list of relative paths of files
      */
-    @NonNull
     private static List<String> getFileNames(
-            @NonNull File directory,
-            @Nullable String includes,
-            @Nullable String excludes,
-            boolean includeBasedir,
-            boolean isCaseSensitive) {
+            File directory, String includes, String excludes, boolean includeBasedir, boolean isCaseSensitive) {
         return getFileAndDirectoryNames(directory, includes, excludes, includeBasedir, isCaseSensitive, true, false);
     }
 
@@ -1351,10 +1313,8 @@ public class FileUtils {
      * @return a list of relative paths of directories
      * @throws IOException never
      */
-    @NonNull
     public static List<String> getDirectoryNames(
-            @NonNull File directory, @Nullable String includes, @Nullable String excludes, boolean includeBasedir)
-            throws IOException {
+            File directory, String includes, String excludes, boolean includeBasedir) throws IOException {
         return getDirectoryNames(directory, includes, excludes, includeBasedir, true);
     }
 
@@ -1370,13 +1330,8 @@ public class FileUtils {
      * @return a list of relative paths of directories
      * @throws IOException never
      */
-    @NonNull
     public static List<String> getDirectoryNames(
-            @NonNull File directory,
-            @Nullable String includes,
-            @Nullable String excludes,
-            boolean includeBasedir,
-            boolean isCaseSensitive)
+            File directory, String includes, String excludes, boolean includeBasedir, boolean isCaseSensitive)
             throws IOException {
         return getFileAndDirectoryNames(directory, includes, excludes, includeBasedir, isCaseSensitive, false, true);
     }
@@ -1394,11 +1349,10 @@ public class FileUtils {
      * @param getDirectories  true to include directories in the list
      * @return a list of relative paths
      */
-    @NonNull
     public static List<String> getFileAndDirectoryNames(
             File directory,
-            @Nullable String includes,
-            @Nullable String excludes,
+            String includes,
+            String excludes,
             boolean includeBasedir,
             boolean isCaseSensitive,
             boolean getFiles,
@@ -1458,8 +1412,7 @@ public class FileUtils {
      * @deprecated use {@code org.apache.commons.io.FileUtils.copyDirectory()}
      */
     @Deprecated
-    public static void copyDirectory(@NonNull File sourceDirectory, @NonNull File destinationDirectory)
-            throws IOException {
+    public static void copyDirectory(File sourceDirectory, File destinationDirectory) throws IOException {
         Objects.requireNonNull(sourceDirectory);
         Objects.requireNonNull(destinationDirectory);
         if (destinationDirectory.equals(sourceDirectory)) {
@@ -1484,11 +1437,7 @@ public class FileUtils {
      * @deprecated use {@code org.apache.commons.io.FileUtils.copyDirectory()}
      */
     @Deprecated
-    public static void copyDirectory(
-            @NonNull File sourceDirectory,
-            @NonNull File destinationDirectory,
-            @Nullable String includes,
-            @Nullable String excludes)
+    public static void copyDirectory(File sourceDirectory, File destinationDirectory, String includes, String excludes)
             throws IOException {
         if (!sourceDirectory.exists()) {
             return;
@@ -1517,16 +1466,12 @@ public class FileUtils {
      * @deprecated use {@code org.apache.commons.io.FileUtils.copyDirectory()}
      */
     @Deprecated
-    public static void copyDirectoryStructure(@NonNull File sourceDirectory, @NonNull File destinationDirectory)
-            throws IOException {
+    public static void copyDirectoryStructure(File sourceDirectory, File destinationDirectory) throws IOException {
         copyDirectoryStructure(sourceDirectory, destinationDirectory, destinationDirectory, false);
     }
 
     private static void copyDirectoryStructure(
-            @NonNull File sourceDirectory,
-            @NonNull File destinationDirectory,
-            File rootDestinationDirectory,
-            boolean onlyModifiedFiles)
+            File sourceDirectory, File destinationDirectory, File rootDestinationDirectory, boolean onlyModifiedFiles)
             throws IOException {
         //noinspection ConstantConditions
         if (sourceDirectory == null) {
@@ -1601,7 +1546,7 @@ public class FileUtils {
      * @deprecated use {@code java.nio.file.Files.move()}
      */
     @Deprecated
-    public static void rename(@NonNull File from, @NonNull File to) throws IOException {
+    public static void rename(File from, File to) throws IOException {
         if (to.exists() && !deleteLegacyStyle(to)) {
             throw new IOException("Failed to delete " + to + " while trying to rename " + from);
         }
@@ -1642,7 +1587,7 @@ public class FileUtils {
      * @deprecated use {@code java.nio.file.Files.createTempFile()}
      */
     @Deprecated
-    public static File createTempFile(@NonNull String prefix, @NonNull String suffix, @Nullable File parentDir) {
+    public static File createTempFile(String prefix, String suffix, File parentDir) {
         File result;
         String parent = System.getProperty("java.io.tmpdir");
         if (parentDir != null) {
@@ -1678,9 +1623,7 @@ public class FileUtils {
      * @deprecated use {@code org.apache.maven.shared.filtering.FilteringUtils.copyFile()} instead
      */
     @Deprecated
-    public static void copyFile(
-            @NonNull File from, @NonNull File to, @Nullable String encoding, @Nullable FilterWrapper... wrappers)
-            throws IOException {
+    public static void copyFile(File from, File to, String encoding, FilterWrapper... wrappers) throws IOException {
         copyFile(from, to, encoding, wrappers, false);
     }
 
@@ -1712,12 +1655,7 @@ public class FileUtils {
      * @deprecated use {@code org.apache.maven.shared.filtering.FilteringUtils.copyFile()} instead
      */
     @Deprecated
-    public static void copyFile(
-            @NonNull File from,
-            @NonNull File to,
-            @Nullable String encoding,
-            @Nullable FilterWrapper[] wrappers,
-            boolean overwrite)
+    public static void copyFile(File from, File to, String encoding, FilterWrapper[] wrappers, boolean overwrite)
             throws IOException {
         if (wrappers == null || wrappers.length == 0) {
             if (overwrite || !to.exists() || to.lastModified() < from.lastModified()) {
@@ -1808,7 +1746,7 @@ public class FileUtils {
      * @param source the file to copy permissions from
      * @param destination the file to copy permissions to
      */
-    private static void copyFilePermissions(@NonNull File source, @NonNull File destination) throws IOException {
+    private static void copyFilePermissions(File source, File destination) throws IOException {
         try {
             // attempt to copy posix file permissions
             Files.setPosixFilePermissions(destination.toPath(), Files.getPosixFilePermissions(source.toPath()));
@@ -1829,8 +1767,7 @@ public class FileUtils {
      * @deprecated assumes the platform default character set
      */
     @Deprecated
-    @NonNull
-    public static List<String> loadFile(@NonNull File file) throws IOException {
+    public static List<String> loadFile(File file) throws IOException {
         List<String> lines = new ArrayList<>();
 
         if (file.exists()) {
@@ -1870,7 +1807,7 @@ public class FileUtils {
      * <code>true</code> if the Os is not Windows or if the file path respect the Windows constraints
      * @see #INVALID_CHARACTERS_FOR_WINDOWS_FILE_NAME
      */
-    private static boolean isValidWindowsFileName(@NonNull File f) {
+    private static boolean isValidWindowsFileName(File f) {
         if (Os.isFamily(Os.FAMILY_WINDOWS)) {
             if (StringUtils.indexOfAny(f.getName(), INVALID_CHARACTERS_FOR_WINDOWS_FILE_NAME) != -1) {
                 return false;
@@ -1893,7 +1830,7 @@ public class FileUtils {
      * @deprecated use {@code java.nio.file.Files.isSymbolicLink(file.toPath())}
      */
     @Deprecated
-    public static boolean isSymbolicLink(@NonNull final File file) throws IOException {
+    public static boolean isSymbolicLink(final File file) throws IOException {
         return Files.isSymbolicLink(file.toPath());
     }
 
@@ -1906,7 +1843,7 @@ public class FileUtils {
      * @deprecated use {@code java.nio.file.Files.isSymbolicLink(file.toPath())}
      */
     @Deprecated
-    public static boolean isSymbolicLinkForSure(@NonNull final File file) throws IOException {
+    public static boolean isSymbolicLinkForSure(final File file) throws IOException {
         return Files.isSymbolicLink(file.toPath());
     }
 
@@ -1920,8 +1857,7 @@ public class FileUtils {
      * @see Files#createSymbolicLink(Path, Path, FileAttribute[]) which creates a new symbolic link but does
      * not replace existing symbolic links
      */
-    @NonNull
-    public static File createSymbolicLink(@NonNull File symlink, @NonNull File target) throws IOException {
+    public static File createSymbolicLink(File symlink, File target) throws IOException {
         final Path symlinkPath = symlink.toPath();
 
         if (Files.exists(symlinkPath)) {

--- a/src/main/java/org/apache/maven/shared/utils/io/IOUtil.java
+++ b/src/main/java/org/apache/maven/shared/utils/io/IOUtil.java
@@ -32,9 +32,6 @@ import java.io.StringWriter;
 import java.io.Writer;
 import java.nio.channels.Channel;
 
-import org.jspecify.annotations.NonNull;
-import org.jspecify.annotations.Nullable;
-
 /**
  * <p>General IO Stream manipulation.</p>
  * <p>
@@ -132,7 +129,7 @@ public final class IOUtil
      *         Java 9 and later {@code InputStream.transferTo()}.
      */
     @Deprecated
-    public static void copy(@NonNull final InputStream input, @NonNull final OutputStream output) throws IOException {
+    public static void copy(final InputStream input, final OutputStream output) throws IOException {
         copy(input, output, DEFAULT_BUFFER_SIZE);
     }
 
@@ -149,7 +146,7 @@ public final class IOUtil
      *         Java 9 and later {@code InputStream.transferTo()}.
      */
     @Deprecated
-    public static void copy(@NonNull final InputStream input, @NonNull final OutputStream output, final int bufferSize)
+    public static void copy(final InputStream input, final OutputStream output, final int bufferSize)
             throws IOException {
         final byte[] buffer = new byte[bufferSize];
         int n;
@@ -166,7 +163,7 @@ public final class IOUtil
      * @throws IOException in case of failure     * @deprecated use {@code org.apache.commons.io.IOUtils.copy()}
      */
     @Deprecated
-    public static void copy(@NonNull final Reader input, @NonNull final Writer output) throws IOException {
+    public static void copy(final Reader input, final Writer output) throws IOException {
         copy(input, output, DEFAULT_BUFFER_SIZE);
     }
 
@@ -180,8 +177,7 @@ public final class IOUtil
      * @deprecated use {@code org.apache.commons.io.IOUtils.copy()}.
      */
     @Deprecated
-    public static void copy(@NonNull final Reader input, @NonNull final Writer output, final int bufferSize)
-            throws IOException {
+    public static void copy(final Reader input, final Writer output, final int bufferSize) throws IOException {
         final char[] buffer = new char[bufferSize];
         int n;
         while (-1 != (n = input.read(buffer))) {
@@ -210,7 +206,7 @@ public final class IOUtil
      * @deprecated use {@code org.apache.commons.io.IOUtils.copy()}.
      */
     @Deprecated
-    public static void copy(@NonNull final InputStream input, @NonNull final Writer output) throws IOException {
+    public static void copy(final InputStream input, final Writer output) throws IOException {
         copy(input, output, DEFAULT_BUFFER_SIZE);
     }
 
@@ -226,8 +222,7 @@ public final class IOUtil
      * @deprecated use {@code org.apache.commons.io.IOUtils.copy()}.
      */
     @Deprecated
-    public static void copy(@NonNull final InputStream input, @NonNull final Writer output, final int bufferSize)
-            throws IOException {
+    public static void copy(final InputStream input, final Writer output, final int bufferSize) throws IOException {
         final InputStreamReader in = new InputStreamReader(input);
         copy(in, output, bufferSize);
     }
@@ -245,9 +240,7 @@ public final class IOUtil
      * @deprecated use {@code org.apache.commons.io.IOUtils.copy()}.
      */
     @Deprecated
-    public static void copy(
-            @NonNull final InputStream input, @NonNull final Writer output, @NonNull final String encoding)
-            throws IOException {
+    public static void copy(final InputStream input, final Writer output, final String encoding) throws IOException {
         final InputStreamReader in = new InputStreamReader(input, encoding);
         copy(in, output);
     }
@@ -266,11 +259,7 @@ public final class IOUtil
      * @deprecated use {@code org.apache.commons.io.IOUtils.copy()}.
      */
     @Deprecated
-    public static void copy(
-            @NonNull final InputStream input,
-            @NonNull final Writer output,
-            @NonNull final String encoding,
-            final int bufferSize)
+    public static void copy(final InputStream input, final Writer output, final String encoding, final int bufferSize)
             throws IOException {
         final InputStreamReader in = new InputStreamReader(input, encoding);
         copy(in, output, bufferSize);
@@ -289,8 +278,7 @@ public final class IOUtil
      * @deprecated always specify a character encoding
      */
     @Deprecated
-    @NonNull
-    public static String toString(@NonNull final InputStream input) throws IOException {
+    public static String toString(final InputStream input) throws IOException {
         return toString(input, DEFAULT_BUFFER_SIZE);
     }
 
@@ -305,8 +293,7 @@ public final class IOUtil
      * @deprecated always specify a character encoding
      */
     @Deprecated
-    @NonNull
-    public static String toString(@NonNull final InputStream input, final int bufferSize) throws IOException {
+    public static String toString(final InputStream input, final int bufferSize) throws IOException {
         final StringWriter sw = new StringWriter();
         copy(input, sw, bufferSize);
         return sw.toString();
@@ -324,8 +311,7 @@ public final class IOUtil
      * @deprecated use {@code org.apache.commons.io.IOUtils.toString()}.
      */
     @Deprecated
-    @NonNull
-    public static String toString(@NonNull final InputStream input, @NonNull final String encoding) throws IOException {
+    public static String toString(final InputStream input, final String encoding) throws IOException {
         return toString(input, encoding, DEFAULT_BUFFER_SIZE);
     }
 
@@ -342,9 +328,8 @@ public final class IOUtil
      * @deprecated use {@code org.apache.commons.io.IOUtils.toString()}.
      */
     @Deprecated
-    @NonNull
-    public static String toString(
-            @NonNull final InputStream input, @NonNull final String encoding, final int bufferSize) throws IOException {
+    public static String toString(final InputStream input, final String encoding, final int bufferSize)
+            throws IOException {
         final StringWriter sw = new StringWriter();
         copy(input, sw, encoding, bufferSize);
         return sw.toString();
@@ -362,8 +347,7 @@ public final class IOUtil
      * @deprecated use {@code org.apache.commons.io.IOUtils.readFully()}.
      */
     @Deprecated
-    @NonNull
-    public static byte[] toByteArray(@NonNull final InputStream input) throws IOException {
+    public static byte[] toByteArray(final InputStream input) throws IOException {
         return toByteArray(input, DEFAULT_BUFFER_SIZE);
     }
 
@@ -377,8 +361,7 @@ public final class IOUtil
      * @deprecated use {@code org.apache.commons.io.IOUtils.readFully()}.
      */
     @Deprecated
-    @NonNull
-    public static byte[] toByteArray(@NonNull final InputStream input, final int bufferSize) throws IOException {
+    public static byte[] toByteArray(final InputStream input, final int bufferSize) throws IOException {
         final ByteArrayOutputStream output = new ByteArrayOutputStream();
         copy(input, output, bufferSize);
         return output.toByteArray();
@@ -402,7 +385,7 @@ public final class IOUtil
      * @deprecated always specify a character encoding
      */
     @Deprecated
-    public static void copy(@NonNull final Reader input, @NonNull final OutputStream output) throws IOException {
+    public static void copy(final Reader input, final OutputStream output) throws IOException {
         copy(input, output, DEFAULT_BUFFER_SIZE);
     }
 
@@ -417,8 +400,7 @@ public final class IOUtil
      * @deprecated always specify a character encoding
      */
     @Deprecated
-    public static void copy(@NonNull final Reader input, @NonNull final OutputStream output, final int bufferSize)
-            throws IOException {
+    public static void copy(final Reader input, final OutputStream output, final int bufferSize) throws IOException {
         final OutputStreamWriter out = new OutputStreamWriter(output);
         copy(input, out, bufferSize);
         // NOTE: Unless anyone is planning on rewriting OutputStreamWriter, we have to flush
@@ -438,8 +420,7 @@ public final class IOUtil
      * @deprecated use {@code org.apache.commons.io.IOUtils.toString()}.
      */
     @Deprecated
-    @NonNull
-    public static String toString(@NonNull final Reader input) throws IOException {
+    public static String toString(final Reader input) throws IOException {
         return toString(input, DEFAULT_BUFFER_SIZE);
     }
 
@@ -453,8 +434,7 @@ public final class IOUtil
      * @deprecated use {@code org.apache.commons.io.IOUtils.toString()}.
      */
     @Deprecated
-    @NonNull
-    public static String toString(@NonNull final Reader input, final int bufferSize) throws IOException {
+    public static String toString(final Reader input, final int bufferSize) throws IOException {
         final StringWriter sw = new StringWriter();
         copy(input, sw, bufferSize);
         return sw.toString();
@@ -472,8 +452,7 @@ public final class IOUtil
      * @deprecated always specify a character encoding
      */
     @Deprecated
-    @NonNull
-    public static byte[] toByteArray(@NonNull final Reader input) throws IOException {
+    public static byte[] toByteArray(final Reader input) throws IOException {
         return toByteArray(input, DEFAULT_BUFFER_SIZE);
     }
 
@@ -487,8 +466,7 @@ public final class IOUtil
      * @deprecated always specify a character encoding
      */
     @Deprecated
-    @NonNull
-    public static byte[] toByteArray(@NonNull final Reader input, final int bufferSize) throws IOException {
+    public static byte[] toByteArray(final Reader input, final int bufferSize) throws IOException {
         ByteArrayOutputStream output = new ByteArrayOutputStream();
         copy(input, output, bufferSize);
         return output.toByteArray();
@@ -512,7 +490,7 @@ public final class IOUtil
      * @deprecated always specify a character encoding
      */
     @Deprecated
-    public static void copy(@NonNull final String input, @NonNull final OutputStream output) throws IOException {
+    public static void copy(final String input, final OutputStream output) throws IOException {
         copy(input, output, DEFAULT_BUFFER_SIZE);
     }
 
@@ -527,8 +505,7 @@ public final class IOUtil
      * @deprecated always specify a character encoding
      */
     @Deprecated
-    public static void copy(@NonNull final String input, @NonNull final OutputStream output, final int bufferSize)
-            throws IOException {
+    public static void copy(final String input, final OutputStream output, final int bufferSize) throws IOException {
         final StringReader in = new StringReader(input);
         final OutputStreamWriter out = new OutputStreamWriter(output);
         copy(in, out, bufferSize);
@@ -549,7 +526,7 @@ public final class IOUtil
      * @deprecated use {@code org.apache.commons.io.IOUtils.write()}.
      */
     @Deprecated
-    public static void copy(@NonNull final String input, @NonNull final Writer output) throws IOException {
+    public static void copy(final String input, final Writer output) throws IOException {
         output.write(input);
     }
 
@@ -565,8 +542,7 @@ public final class IOUtil
      * @deprecated always specify a character encoding
      */
     @Deprecated
-    @NonNull
-    public static byte[] toByteArray(@NonNull final String input) throws IOException {
+    public static byte[] toByteArray(final String input) throws IOException {
         return toByteArray(input, DEFAULT_BUFFER_SIZE);
     }
 
@@ -580,8 +556,7 @@ public final class IOUtil
      * @deprecated always specify a character encoding
      */
     @Deprecated
-    @NonNull
-    public static byte[] toByteArray(@NonNull final String input, final int bufferSize) throws IOException {
+    public static byte[] toByteArray(final String input, final int bufferSize) throws IOException {
         ByteArrayOutputStream output = new ByteArrayOutputStream();
         copy(input, output, bufferSize);
         return output.toByteArray();
@@ -606,7 +581,7 @@ public final class IOUtil
      * @deprecated always specify a character encoding
      */
     @Deprecated
-    public static void copy(@NonNull final byte[] input, @NonNull final Writer output) throws IOException {
+    public static void copy(final byte[] input, final Writer output) throws IOException {
         copy(input, output, DEFAULT_BUFFER_SIZE);
     }
 
@@ -622,8 +597,7 @@ public final class IOUtil
      * @deprecated always specify a character encoding
      */
     @Deprecated
-    public static void copy(@NonNull final byte[] input, @NonNull final Writer output, final int bufferSize)
-            throws IOException {
+    public static void copy(final byte[] input, final Writer output, final int bufferSize) throws IOException {
         final ByteArrayInputStream in = new ByteArrayInputStream(input);
         copy(in, output, bufferSize);
     }
@@ -641,8 +615,7 @@ public final class IOUtil
      * @deprecated use {@code org.apache.commons.io.IOUtils.write()}.
      */
     @Deprecated
-    public static void copy(@NonNull final byte[] input, @NonNull final Writer output, final String encoding)
-            throws IOException {
+    public static void copy(final byte[] input, final Writer output, final String encoding) throws IOException {
         final ByteArrayInputStream in = new ByteArrayInputStream(input);
         copy(in, output, encoding);
     }
@@ -661,11 +634,7 @@ public final class IOUtil
      * @deprecated use {@code org.apache.commons.io.IOUtils.write()}.
      */
     @Deprecated
-    public static void copy(
-            @NonNull final byte[] input,
-            @NonNull final Writer output,
-            @NonNull final String encoding,
-            final int bufferSize)
+    public static void copy(final byte[] input, final Writer output, final String encoding, final int bufferSize)
             throws IOException {
         final ByteArrayInputStream in = new ByteArrayInputStream(input);
         copy(in, output, encoding, bufferSize);
@@ -684,8 +653,7 @@ public final class IOUtil
      * @deprecated always specify a character encoding
      */
     @Deprecated
-    @NonNull
-    public static String toString(@NonNull final byte[] input) throws IOException {
+    public static String toString(final byte[] input) throws IOException {
         return toString(input, DEFAULT_BUFFER_SIZE);
     }
 
@@ -700,8 +668,7 @@ public final class IOUtil
      * @deprecated always specify a character encoding
      */
     @Deprecated
-    @NonNull
-    public static String toString(@NonNull final byte[] input, final int bufferSize) throws IOException {
+    public static String toString(final byte[] input, final int bufferSize) throws IOException {
         final StringWriter sw = new StringWriter();
         copy(input, sw, bufferSize);
         return sw.toString();
@@ -719,8 +686,7 @@ public final class IOUtil
      * @deprecated use {@code new String(input, encoding)}
      */
     @Deprecated
-    @NonNull
-    public static String toString(@NonNull final byte[] input, @NonNull final String encoding) throws IOException {
+    public static String toString(final byte[] input, final String encoding) throws IOException {
         return toString(input, encoding, DEFAULT_BUFFER_SIZE);
     }
 
@@ -737,9 +703,7 @@ public final class IOUtil
      * @deprecated use {@code new String(input, encoding)}
      */
     @Deprecated
-    @NonNull
-    public static String toString(@NonNull final byte[] input, @NonNull final String encoding, final int bufferSize)
-            throws IOException {
+    public static String toString(final byte[] input, final String encoding, final int bufferSize) throws IOException {
         final StringWriter sw = new StringWriter();
         copy(input, sw, encoding, bufferSize);
         return sw.toString();
@@ -757,7 +721,7 @@ public final class IOUtil
      * @deprecated inline this method
      */
     @Deprecated
-    public static void copy(@NonNull final byte[] input, @NonNull final OutputStream output) throws IOException {
+    public static void copy(final byte[] input, final OutputStream output) throws IOException {
         output.write(input);
     }
 
@@ -771,8 +735,7 @@ public final class IOUtil
      * @deprecated use {@code org.apache.commons.io.IOUtils.contentEquals()}
      */
     @Deprecated
-    public static boolean contentEquals(@NonNull final InputStream input1, @NonNull final InputStream input2)
-            throws IOException {
+    public static boolean contentEquals(final InputStream input1, final InputStream input2) throws IOException {
         final InputStream bufferedInput1 = new BufferedInputStream(input1);
         final InputStream bufferedInput2 = new BufferedInputStream(input2);
 
@@ -884,7 +847,7 @@ public final class IOUtil
      * @deprecated use try-with-resources
      */
     @Deprecated
-    public static void close(@Nullable Channel channel) {
+    public static void close(Channel channel) {
         try {
             if (channel != null) {
                 channel.close();
@@ -985,7 +948,7 @@ public final class IOUtil
      * @deprecated use try-with-resources
      */
     @Deprecated
-    public static void close(@Nullable InputStream inputStream) {
+    public static void close(InputStream inputStream) {
         try {
             if (inputStream != null) {
                 inputStream.close();
@@ -1086,7 +1049,7 @@ public final class IOUtil
      * @deprecated use try-with-resources
      */
     @Deprecated
-    public static void close(@Nullable OutputStream outputStream) {
+    public static void close(OutputStream outputStream) {
         try {
             if (outputStream != null) {
                 outputStream.close();
@@ -1187,7 +1150,7 @@ public final class IOUtil
      * @deprecated use try-with-resources
      */
     @Deprecated
-    public static void close(@Nullable Reader reader) {
+    public static void close(Reader reader) {
         try {
             if (reader != null) {
                 reader.close();
@@ -1288,7 +1251,7 @@ public final class IOUtil
      * @deprecated use try-with-resources
      */
     @Deprecated
-    public static void close(@Nullable Writer writer) {
+    public static void close(Writer writer) {
         try {
             if (writer != null) {
                 writer.close();

--- a/src/main/java/org/apache/maven/shared/utils/io/Java7Support.java
+++ b/src/main/java/org/apache/maven/shared/utils/io/Java7Support.java
@@ -22,8 +22,6 @@ import java.io.File;
 import java.io.IOException;
 import java.nio.file.Files;
 
-import org.jspecify.annotations.NonNull;
-
 /**
  * Java7 feature detection.
  *
@@ -36,7 +34,7 @@ public class Java7Support {
      * @param file the file to check for being a symbolic link
      * @return true if the file is a symlink false otherwise
      */
-    public static boolean isSymLink(@NonNull File file) {
+    public static boolean isSymLink(File file) {
         return Files.isSymbolicLink(file.toPath());
     }
 
@@ -45,8 +43,7 @@ public class Java7Support {
      * @return the file
      * @throws IOException in case of error
      */
-    @NonNull
-    public static File readSymbolicLink(@NonNull File symlink) throws IOException {
+    public static File readSymbolicLink(File symlink) throws IOException {
         return Files.readSymbolicLink(symlink.toPath()).toFile();
     }
 
@@ -55,7 +52,7 @@ public class Java7Support {
      * @return true if exist false otherwise
      * @throws IOException in case of failure
      */
-    public static boolean exists(@NonNull File file) throws IOException {
+    public static boolean exists(File file) throws IOException {
         return Files.exists(file.toPath());
     }
 
@@ -65,8 +62,7 @@ public class Java7Support {
      * @return the linked file
      * @throws IOException in case of an error
      */
-    @NonNull
-    public static File createSymbolicLink(@NonNull File symlink, @NonNull File target) throws IOException {
+    public static File createSymbolicLink(File symlink, File target) throws IOException {
         return FileUtils.createSymbolicLink(symlink, target);
     }
 
@@ -76,7 +72,7 @@ public class Java7Support {
      * @param file the file to delete
      * @throws IOException in case of error
      */
-    public static void delete(@NonNull File file) throws IOException {
+    public static void delete(File file) throws IOException {
         Files.delete(file.toPath());
     }
 

--- a/src/main/java/org/apache/maven/shared/utils/io/MatchPattern.java
+++ b/src/main/java/org/apache/maven/shared/utils/io/MatchPattern.java
@@ -24,8 +24,6 @@ import java.util.List;
 import java.util.StringTokenizer;
 import java.util.regex.Pattern;
 
-import org.jspecify.annotations.NonNull;
-
 /**
  * <p>Describes a match target for SelectorUtils.</p>
  * <p>
@@ -46,7 +44,7 @@ public class MatchPattern {
 
     private final String[] tokenized;
 
-    private MatchPattern(@NonNull String source, @NonNull String separator) {
+    private MatchPattern(String source, String separator) {
         regexPattern = SelectorUtils.isRegexPrefixedPattern(source)
                 ? source.substring(
                         SelectorUtils.REGEX_HANDLER_PREFIX.length(),
@@ -88,7 +86,7 @@ public class MatchPattern {
      * @param isCaseSensitive check case sensitive or not
      * @return true in case of matching pattern
      */
-    public boolean matchPatternStart(@NonNull String str, boolean isCaseSensitive) {
+    public boolean matchPatternStart(String str, boolean isCaseSensitive) {
         if (regexPattern != null) {
             // FIXME: ICK! But we can't do partial matches for regex, so we have to reserve judgment until we have
             // a file to deal with, or we can definitely say this is an exclusion...
@@ -116,7 +114,7 @@ public class MatchPattern {
         return source.startsWith(string);
     }
 
-    static String[] tokenizePathToString(@NonNull String path, @NonNull String separator) {
+    static String[] tokenizePathToString(String path, String separator) {
         List<String> ret = new ArrayList<>();
         StringTokenizer st = new StringTokenizer(path, separator);
         while (st.hasMoreTokens()) {

--- a/src/main/java/org/apache/maven/shared/utils/io/MatchPatterns.java
+++ b/src/main/java/org/apache/maven/shared/utils/io/MatchPatterns.java
@@ -20,8 +20,6 @@ package org.apache.maven.shared.utils.io;
 
 import java.io.File;
 
-import org.jspecify.annotations.NonNull;
-
 /**
  * A list of patterns to be matched.
  *
@@ -32,7 +30,7 @@ import org.jspecify.annotations.NonNull;
 public class MatchPatterns {
     private final MatchPattern[] patterns;
 
-    private MatchPatterns(@NonNull MatchPattern... patterns) {
+    private MatchPatterns(MatchPattern... patterns) {
         this.patterns = patterns;
     }
 
@@ -44,7 +42,7 @@ public class MatchPatterns {
      * @param isCaseSensitive if the comparison is case sensitive
      * @return true if any of the supplied patterns match
      */
-    public boolean matches(@NonNull String name, boolean isCaseSensitive) {
+    public boolean matches(String name, boolean isCaseSensitive) {
         String[] tokenized = MatchPattern.tokenizePathToString(name, File.separator);
         for (MatchPattern pattern : patterns) {
             if (pattern.matchPath(name, tokenized, isCaseSensitive)) {
@@ -59,7 +57,7 @@ public class MatchPatterns {
      * @param isCaseSensitive being case sensetive
      * @return true if any of the supplied patterns match start
      */
-    public boolean matchesPatternStart(@NonNull String name, boolean isCaseSensitive) {
+    public boolean matchesPatternStart(String name, boolean isCaseSensitive) {
         for (MatchPattern includesPattern : patterns) {
             if (includesPattern.matchPatternStart(name, isCaseSensitive)) {
                 return true;
@@ -72,7 +70,7 @@ public class MatchPatterns {
      * @param sources the sources
      * @return converted match patterns
      */
-    public static MatchPatterns from(@NonNull String... sources) {
+    public static MatchPatterns from(String... sources) {
         final int length = sources.length;
         MatchPattern[] result = new MatchPattern[length];
         for (int i = 0; i < length; i++) {

--- a/src/main/java/org/apache/maven/shared/utils/io/SelectorUtils.java
+++ b/src/main/java/org/apache/maven/shared/utils/io/SelectorUtils.java
@@ -23,8 +23,6 @@ import java.util.ArrayList;
 import java.util.List;
 import java.util.StringTokenizer;
 
-import org.jspecify.annotations.NonNull;
-
 /**
  * <p>This is a utility class used by selectors and DirectoryScanner. The
  * functionality more properly belongs just to selectors, but unfortunately
@@ -512,12 +510,12 @@ public final class SelectorUtils {
     }
 
     static boolean matchAntPathPatternStart(
-            @NonNull MatchPattern pattern, @NonNull String str, @NonNull String separator, boolean isCaseSensitive) {
+            MatchPattern pattern, String str, String separator, boolean isCaseSensitive) {
         return !separatorPatternStartSlashMismatch(pattern, str, separator)
                 && matchAntPathPatternStart(pattern.getTokenizedPathString(), str, separator, isCaseSensitive);
     }
 
-    private static String[] tokenizePathToString(@NonNull String path, @NonNull String separator) {
+    private static String[] tokenizePathToString(String path, String separator) {
         List<String> ret = new ArrayList<>();
         StringTokenizer st = new StringTokenizer(path, separator);
         while (st.hasMoreTokens()) {
@@ -527,13 +525,13 @@ public final class SelectorUtils {
     }
 
     private static boolean matchAntPathPatternStart(
-            @NonNull String[] patDirs, @NonNull String str, @NonNull String separator, boolean isCaseSensitive) {
+            String[] patDirs, String str, String separator, boolean isCaseSensitive) {
         String[] strDirs = tokenizePathToString(str, separator);
         return matchAntPathPatternStart(patDirs, strDirs, isCaseSensitive);
     }
 
     private static boolean matchAntPathPatternStart(
-            @NonNull String[] patDirs, @NonNull String[] tokenizedFileName, boolean isCaseSensitive) {
+            String[] patDirs, String[] tokenizedFileName, boolean isCaseSensitive) {
 
         int patIdxStart = 0;
         int patIdxEnd = patDirs.length - 1;
@@ -556,8 +554,7 @@ public final class SelectorUtils {
         return strIdxStart > strIdxEnd || patIdxStart <= patIdxEnd;
     }
 
-    private static boolean separatorPatternStartSlashMismatch(
-            @NonNull MatchPattern matchPattern, @NonNull String str, @NonNull String separator) {
+    private static boolean separatorPatternStartSlashMismatch(MatchPattern matchPattern, String str, String separator) {
         return str.startsWith(separator) != matchPattern.startsWith(separator);
     }
 
@@ -682,10 +679,7 @@ public final class SelectorUtils {
     }
 
     static boolean matchAntPathPattern(
-            @NonNull MatchPattern matchPattern,
-            @NonNull String str,
-            @NonNull String separator,
-            boolean isCaseSensitive) {
+            MatchPattern matchPattern, String str, String separator, boolean isCaseSensitive) {
         if (separatorPatternStartSlashMismatch(matchPattern, str, separator)) {
             return false;
         }

--- a/src/main/java/org/apache/maven/shared/utils/xml/Xpp3Dom.java
+++ b/src/main/java/org/apache/maven/shared/utils/xml/Xpp3Dom.java
@@ -27,8 +27,6 @@ import java.util.Iterator;
 import java.util.List;
 import java.util.Map;
 
-import org.jspecify.annotations.NonNull;
-
 /**
  * A reimplementation of Plexus Xpp3Dom based on the public interface of Plexus Xpp3Dom.
  *
@@ -114,7 +112,7 @@ public class Xpp3Dom implements Iterable<Xpp3Dom> {
      * @param src the source Dom
      * @param name the name of the Dom
      */
-    public Xpp3Dom(@NonNull Xpp3Dom src, String name) {
+    public Xpp3Dom(Xpp3Dom src, String name) {
         this.name = name;
 
         int size = src.getChildCount();
@@ -142,7 +140,6 @@ public class Xpp3Dom implements Iterable<Xpp3Dom> {
     /**
      * @return the current value
      */
-    @NonNull
     public String getValue() {
         return value != null ? value : "";
     }
@@ -150,7 +147,7 @@ public class Xpp3Dom implements Iterable<Xpp3Dom> {
     /**
      * @param value the value to be set
      */
-    public void setValue(@NonNull String value) {
+    public void setValue(String value) {
         this.value = value;
     }
 
@@ -174,7 +171,7 @@ public class Xpp3Dom implements Iterable<Xpp3Dom> {
      * @param nameParameter the name of the attribute
      * @param valueParameter the value of the attribute
      */
-    public void setAttribute(@NonNull String nameParameter, @NonNull String valueParameter) {
+    public void setAttribute(String nameParameter, String valueParameter) {
         if (valueParameter == null) {
             throw new NullPointerException("value can not be null");
         }

--- a/src/main/java/org/apache/maven/shared/utils/xml/Xpp3DomBuilder.java
+++ b/src/main/java/org/apache/maven/shared/utils/xml/Xpp3DomBuilder.java
@@ -27,7 +27,6 @@ import java.util.ArrayList;
 import java.util.List;
 
 import org.apache.maven.shared.utils.xml.pull.XmlPullParserException;
-import org.jspecify.annotations.NonNull;
 import org.xml.sax.Attributes;
 import org.xml.sax.InputSource;
 import org.xml.sax.SAXException;
@@ -46,7 +45,7 @@ public class Xpp3DomBuilder {
      * @return the built DOM
      * @throws XmlPullParserException in case of an error
      */
-    public static Xpp3Dom build(@NonNull Reader reader) throws XmlPullParserException {
+    public static Xpp3Dom build(Reader reader) throws XmlPullParserException {
         return build(reader, false);
     }
 
@@ -56,7 +55,7 @@ public class Xpp3DomBuilder {
      * @return the built DOM
      * @throws XmlPullParserException in case of an error
      */
-    public static Xpp3Dom build(InputStream is, @NonNull String encoding) throws XmlPullParserException {
+    public static Xpp3Dom build(InputStream is, String encoding) throws XmlPullParserException {
         return build(is, encoding, false);
     }
 
@@ -69,7 +68,7 @@ public class Xpp3DomBuilder {
      * @deprecated use the two-arg variant
      */
     @Deprecated
-    public static Xpp3Dom build(InputStream is, @NonNull String encoding, boolean noop) throws XmlPullParserException {
+    public static Xpp3Dom build(InputStream is, String encoding, boolean noop) throws XmlPullParserException {
         try {
             Reader reader = new InputStreamReader(is, encoding);
             return build(reader);
@@ -96,7 +95,7 @@ public class Xpp3DomBuilder {
         }
     }
 
-    private static DocHandler parseSax(@NonNull InputSource inputSource) throws XmlPullParserException {
+    private static DocHandler parseSax(InputSource inputSource) throws XmlPullParserException {
         try {
             DocHandler ch = new DocHandler();
             XMLReader parser = createXmlReader();

--- a/src/test/java/org/apache/maven/shared/utils/io/FileUtilsTest.java
+++ b/src/test/java/org/apache/maven/shared/utils/io/FileUtilsTest.java
@@ -42,7 +42,6 @@ import java.util.concurrent.TimeUnit;
 import org.apache.commons.io.IOUtils;
 import org.apache.maven.shared.utils.Os;
 import org.apache.maven.shared.utils.testhelpers.FileTestHelper;
-import org.jspecify.annotations.NonNull;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.Test;
@@ -489,7 +488,7 @@ public class FileUtilsTest {
         };
     }
 
-    private File write(@NonNull String name, long lastModified, @NonNull String text) throws IOException {
+    private File write(String name, long lastModified, String text) throws IOException {
         final File file = new File(tempFolder, name);
         try (Writer writer = new FileWriter(file)) {
             writer.write(text);
@@ -499,7 +498,7 @@ public class FileUtilsTest {
         return file;
     }
 
-    private static void assertFileContent(@NonNull File file, @NonNull String expected) throws IOException {
+    private static void assertFileContent(File file, String expected) throws IOException {
         try (Reader in = new FileReader(file)) {
             assertEquals(expected, IOUtils.toString(in), "Expected " + file.getPath() + " to contain: " + expected);
         }

--- a/src/test/java/org/apache/maven/shared/utils/xml/pull/Xpp3DomTest.java
+++ b/src/test/java/org/apache/maven/shared/utils/xml/pull/Xpp3DomTest.java
@@ -44,8 +44,7 @@ public class Xpp3DomTest {
 
     @Test
     public void defaultValueIsNotNull() {
-        // getValue() is annotated @NonNull but the one-arg constructor
-        // did not initialize value, violating the contract.
+        // The one-arg constructor did not initialize value.
         assertNotNull(new Xpp3Dom("test").getValue());
     }
 


### PR DESCRIPTION
Removes the `org.jspecify:jspecify` dependency and every `@NonNull` / `@Nullable` annotation it supplied, in place of the provided-scope change this PR first proposed. The review on that version asked whether the annotations earn their place at all; they are not checked by any tool in this build, so dropping them is the smaller change to the consumer graph than adjusting the scope.

The diff is large only because spotless re-joins signatures that fit on one line once the annotations are gone. No method body changes.

What consumers see: the runtime annotation metadata disappears from public signatures. Nothing in this library reflects on it, Maven core has no reference to `org.jspecify` at all, and NullAway or similar checkers were never wired into this build. I have not audited the other consumers; one that referenced `org.jspecify` transitively through this artifact would need to declare it itself.

After the change `dependency:list -DincludeScope=runtime` yields `slf4j-api`, `jansi` (optional) and `commons-io`.

Verified: `JAVA_HOME=$(/usr/libexec/java_home -v 17) mvn -B verify` -> Tests run: 788, Failures: 0, Errors: 0 (JDK 17); spotless clean; `dependency:list -DincludeScope=runtime` shows no jspecify

*This change was created with AI assistance.*
