### PR TITLE
Pass streamCharset to the stdout and stderr pumpers

### DIFF
--- a/src/main/java/org/apache/maven/shared/utils/cli/CommandLineUtils.java
+++ b/src/main/java/org/apache/maven/shared/utils/cli/CommandLineUtils.java
@@ -265,11 +265,11 @@ public abstract class CommandLineUtils {
                         inputFeeder.start();
                     }
 
-                    outputPumper = new StreamPumper(p.getInputStream(), systemOut);
+                    outputPumper = new StreamPumper(p.getInputStream(), systemOut, streamCharset);
                     outputPumper.setName("StreamPumper-systemOut");
                     outputPumper.start();
 
-                    errorPumper = new StreamPumper(p.getErrorStream(), systemErr);
+                    errorPumper = new StreamPumper(p.getErrorStream(), systemErr, streamCharset);
                     errorPumper.setName("StreamPumper-systemErr");
                     errorPumper.start();
 

--- a/src/test/java/org/apache/maven/shared/utils/cli/CommandLineUtilsTest.java
+++ b/src/test/java/org/apache/maven/shared/utils/cli/CommandLineUtilsTest.java
@@ -18,6 +18,7 @@
  */
 package org.apache.maven.shared.utils.cli;
 
+import java.nio.charset.StandardCharsets;
 import java.util.Arrays;
 import java.util.HashMap;
 import java.util.Locale;
@@ -141,6 +142,38 @@ public class CommandLineUtilsTest {
             assertEquals(expected.toString(), stdout.getOutput(), "stdout must be complete in iteration " + i);
             assertEquals("", stderr.getOutput(), "stderr must be empty in iteration " + i);
         }
+    }
+
+    @Test
+    public void executeCommandLineDecodesOutputWithTheGivenCharset() throws Exception {
+        if (!Os.isFamily(Os.FAMILY_UNIX)) {
+            return;
+        }
+
+        // the shell emits the UTF-8 bytes of "caf\u00e9" regardless of the JVM default charset
+        String printfUtf8Cafe = "printf 'caf\\303\\251'";
+
+        CommandLineUtils.StringStreamConsumer utf8 = new CommandLineUtils.StringStreamConsumer();
+        CommandLineUtils.executeCommandLine(
+                new Commandline(printfUtf8Cafe),
+                null,
+                utf8,
+                new CommandLineUtils.StringStreamConsumer(),
+                0,
+                null,
+                StandardCharsets.UTF_8);
+        assertEquals("caf\u00e9" + System.lineSeparator(), utf8.getOutput());
+
+        CommandLineUtils.StringStreamConsumer latin1 = new CommandLineUtils.StringStreamConsumer();
+        CommandLineUtils.executeCommandLine(
+                new Commandline(printfUtf8Cafe),
+                null,
+                latin1,
+                new CommandLineUtils.StringStreamConsumer(),
+                0,
+                null,
+                StandardCharsets.ISO_8859_1);
+        assertEquals("caf\u00c3\u00a9" + System.lineSeparator(), latin1.getOutput());
     }
 
     @Test


### PR DESCRIPTION
`executeCommandLineAsCallable` has taken a `Charset` since 3.3.x but never passed it to the two `StreamPumper` instances, so process output was always decoded with the JVM default charset. The synchronous `executeCommandLine` overload with a charset delegates here, so the parameter was dead in both. This wires it through; `StreamPumper` already had the constructor.

The test runs `printf` through the shell to emit the UTF-8 bytes of "café" and decodes them once as UTF-8 and once as ISO-8859-1, so it holds whatever the platform default is. It is Unix-only like the neighbouring large-stdout test.

Fixes #302. PR #60 was closed by the JIRA import, not by a fix.

Verified: `mvn -B verify` on JDK 17 -> Tests run: 792, Failures: 0, Errors: 0; the new test fails on master with `expected: <cafÃ©> but was: <café>`.

*This change was created with AI assistance.*
