### PR TITLE
Copy a symbolic link even when its target does not exist

### DIFF
--- a/src/main/java/org/apache/maven/shared/utils/io/FileUtils.java
+++ b/src/main/java/org/apache/maven/shared/utils/io/FileUtils.java
@@ -709,15 +709,18 @@ public class FileUtils {
      */
     @Deprecated
     public static void copyFile(final File source, final File destination) throws IOException {
+        // a symbolic link is copied as a link, whether or not its target exists
+        if (Files.isSymbolicLink(source.toPath())) {
+            File target = Files.readSymbolicLink(source.toPath()).toFile();
+            mkdirsFor(destination);
+            createSymbolicLink(destination, target);
+            return;
+        }
+
         // check source exists
         if (!source.exists()) {
             final String message = "File " + source + " does not exist";
             throw new IOException(message);
-        }
-        if (Files.isSymbolicLink(source.toPath())) {
-            File target = Files.readSymbolicLink(source.toPath()).toFile();
-            createSymbolicLink(destination, target);
-            return;
         }
 
         // check source != destination, see PLXUTILS-10
@@ -1747,6 +1750,10 @@ public class FileUtils {
      * @param destination the file to copy permissions to
      */
     private static void copyFilePermissions(File source, File destination) throws IOException {
+        if (Files.isSymbolicLink(destination.toPath())) {
+            // a link copied as a link has no permissions of its own, and its target may not exist
+            return;
+        }
         try {
             // attempt to copy posix file permissions
             Files.setPosixFilePermissions(destination.toPath(), Files.getPosixFilePermissions(source.toPath()));

--- a/src/test/java/org/apache/maven/shared/utils/io/FileUtilsTest.java
+++ b/src/test/java/org/apache/maven/shared/utils/io/FileUtilsTest.java
@@ -34,6 +34,7 @@ import java.io.Writer;
 import java.net.URL;
 import java.nio.charset.StandardCharsets;
 import java.nio.file.Files;
+import java.nio.file.Paths;
 import java.util.Arrays;
 import java.util.HashSet;
 import java.util.List;
@@ -343,6 +344,34 @@ public class FileUtilsTest {
         /* disabled: Thread.sleep doesn't work reliantly for this case
         assertTrue("Check last modified date preserved",
             testFile1.lastModified() == destination.lastModified());*/
+    }
+
+    @Test
+    public void copyFileCopiesDanglingSymbolicLink() throws Exception {
+        assumeFalse(Os.isFamily(Os.FAMILY_WINDOWS));
+        File link = new File(tempFolder, "dangling");
+        Files.createSymbolicLink(link.toPath(), Paths.get("non-existing.txt"));
+        File destination = new File(new File(tempFolder, "dest"), "dangling");
+
+        FileUtils.copyFile(link, destination);
+
+        assertTrue(Files.isSymbolicLink(destination.toPath()), "destination is a symbolic link");
+        assertEquals(Paths.get("non-existing.txt"), Files.readSymbolicLink(destination.toPath()));
+    }
+
+    @Test
+    public void copyFileCopiesRelativeSymbolicLinkIntoAnotherDirectory() throws Exception {
+        assumeFalse(Os.isFamily(Os.FAMILY_WINDOWS));
+        Files.write(new File(tempFolder, "target.txt").toPath(), "Hello World!".getBytes(StandardCharsets.UTF_8));
+        File link = new File(tempFolder, "link");
+        Files.createSymbolicLink(link.toPath(), Paths.get("target.txt"));
+        File destination = new File(new File(tempFolder, "dest"), "link");
+
+        // the relative target does not resolve from the destination directory; the link is copied as is
+        FileUtils.copyFile(link, destination, null, (FileUtils.FilterWrapper[]) null);
+
+        assertTrue(Files.isSymbolicLink(destination.toPath()), "destination is a symbolic link");
+        assertEquals(Paths.get("target.txt"), Files.readSymbolicLink(destination.toPath()));
     }
 
     /** A time today, rounded down to the previous minute */


### PR DESCRIPTION
`copyFile(File, File)` checked `source.exists()` before its symbolic-link branch, and `File.exists()` follows links, so a link whose target is missing was rejected as a missing file. The link branch now runs first. Two smaller gaps in the same path surfaced while testing: the link branch did not create the destination directory the way the regular-file path does, and the filtering overload then tried to copy POSIX permissions onto a dangling link, which follows the link and fails. Both are handled in this change.

The two tests follow the scenarios from #110 by @kwin: a dangling link, and a relative link copied into another directory where its target does not resolve. Both are skipped on Windows like the other symlink tests here.

`copyFile` is deprecated in favour of `Files.copy` with `NOFOLLOW_LINKS`, but it still ships, and maven-filtering hit this same path in MSHARED-1112, so the reordered check is worth having.

Fixes #306.

Verified: `mvn -B verify` on JDK 17 -> Tests run: 793, Failures: 0, Errors: 0; on master the dangling-link test fails with `IOException: File .../dangling does not exist`.

*This change was created with AI assistance.*
