### PR TITLE
CmdShell: quote items that cmd.exe would otherwise interpret

### DIFF
--- a/src/main/java/org/apache/maven/shared/utils/cli/shell/CmdShell.java
+++ b/src/main/java/org/apache/maven/shared/utils/cli/shell/CmdShell.java
@@ -28,6 +28,12 @@ import java.util.List;
  */
 public class CmdShell extends Shell {
     /**
+     * Characters that make {@code cmd.exe} interpret an unquoted item: whitespace and, per {@code cmd.exe /?},
+     * {@code &<>()@^|}.
+     */
+    private static final char[] CMD_SPECIAL_CHARS = {' ', '\t', '&', '<', '>', '(', ')', '@', '^', '|'};
+
+    /**
      * Create an instance of CmdShell.
      */
     public CmdShell() {
@@ -76,6 +82,34 @@ public class CmdShell extends Shell {
      * @param arguments the arguments for the executable
      * @return the resulting command line
      */
+    /**
+     * Quotes an item that contains a character {@code cmd.exe} would otherwise interpret: whitespace and the
+     * special characters listed above, or every item when {@link #isUnconditionalQuoting()} is set. An item that
+     * is already surrounded by double quotes is left as it is.
+     *
+     * @param inputString the executable or argument
+     * @param isExecutable unused, the executable and the arguments are quoted the same way
+     * @return the item, surrounded by double quotes when {@code cmd.exe} needs them
+     */
+    @Override
+    protected String quoteOneItem(String inputString, boolean isExecutable) {
+        if (inputString == null || inputString.isEmpty()) {
+            return inputString;
+        }
+        if (inputString.length() > 1 && inputString.startsWith("\"") && inputString.endsWith("\"")) {
+            return inputString;
+        }
+        if (isUnconditionalQuoting()) {
+            return "\"" + inputString + "\"";
+        }
+        for (char c : CMD_SPECIAL_CHARS) {
+            if (inputString.indexOf(c) >= 0) {
+                return "\"" + inputString + "\"";
+            }
+        }
+        return inputString;
+    }
+
     @Override
     public List<String> getCommandLine(String executable, String... arguments) {
         StringBuilder sb = new StringBuilder();

--- a/src/main/java/org/apache/maven/shared/utils/cli/shell/Shell.java
+++ b/src/main/java/org/apache/maven/shared/utils/cli/shell/Shell.java
@@ -35,8 +35,6 @@ import java.util.List;
  * @author <a href="mailto:carlos@apache.org">Carlos Sanchez</a>
  */
 public class Shell {
-    private static final char[] DEFAULT_QUOTING_TRIGGER_CHARS = {' '};
-
     private String shellCommand;
 
     private final List<String> shellArgs = new ArrayList<>();
@@ -140,10 +138,6 @@ public class Shell {
         commandLine.add(sb.toString());
 
         return commandLine;
-    }
-
-    char[] getQuotingTriggerChars() {
-        return DEFAULT_QUOTING_TRIGGER_CHARS;
     }
 
     String getExecutionPreamble() {

--- a/src/test/java/org/apache/maven/shared/utils/cli/CommandLineUtilsTest.java
+++ b/src/test/java/org/apache/maven/shared/utils/cli/CommandLineUtilsTest.java
@@ -18,7 +18,9 @@
  */
 package org.apache.maven.shared.utils.cli;
 
+import java.io.File;
 import java.nio.charset.StandardCharsets;
+import java.nio.file.Files;
 import java.util.Arrays;
 import java.util.HashMap;
 import java.util.Locale;
@@ -27,6 +29,7 @@ import java.util.Properties;
 
 import org.apache.maven.shared.utils.Os;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
@@ -142,6 +145,51 @@ public class CommandLineUtilsTest {
             assertEquals(expected.toString(), stdout.getOutput(), "stdout must be complete in iteration " + i);
             assertEquals("", stderr.getOutput(), "stderr must be empty in iteration " + i);
         }
+    }
+
+    @TempDir
+    File tempDir;
+
+    @Test
+    public void executeCommandLineOnWindowsPassesCmdSpecialCharactersThrough() throws Exception {
+        if (!Os.isFamily(Os.FAMILY_WINDOWS)) {
+            return;
+        }
+
+        // MSHARED-765: unquoted, cmd.exe runs "echo a" and then tries to run "b"
+        Commandline cl = new Commandline();
+        cl.setExecutable("echo");
+        cl.createArg().setValue("a&b");
+
+        CommandLineUtils.StringStreamConsumer stdout = new CommandLineUtils.StringStreamConsumer();
+        CommandLineUtils.StringStreamConsumer stderr = new CommandLineUtils.StringStreamConsumer();
+        int exitCode = CommandLineUtils.executeCommandLine(cl, stdout, stderr);
+
+        assertEquals(0, exitCode, stderr.getOutput());
+        assertEquals("\"a&b\"" + System.lineSeparator(), stdout.getOutput());
+    }
+
+    @Test
+    public void executeCommandLineOnWindowsRunsExecutableFromPathWithParentheses() throws Exception {
+        if (!Os.isFamily(Os.FAMILY_WINDOWS)) {
+            return;
+        }
+
+        // MSHARED-832: C:\work\lol(1)\maven\bin\mvn.cmd
+        File dir = new File(tempDir, "lol(1)");
+        assertTrue(dir.mkdirs());
+        File script = new File(dir, "x.cmd");
+        Files.write(script.toPath(), "@echo ok".getBytes(StandardCharsets.US_ASCII));
+
+        Commandline cl = new Commandline();
+        cl.setExecutable(script.getAbsolutePath());
+
+        CommandLineUtils.StringStreamConsumer stdout = new CommandLineUtils.StringStreamConsumer();
+        CommandLineUtils.StringStreamConsumer stderr = new CommandLineUtils.StringStreamConsumer();
+        int exitCode = CommandLineUtils.executeCommandLine(cl, stdout, stderr);
+
+        assertEquals(0, exitCode, stderr.getOutput());
+        assertEquals("ok" + System.lineSeparator(), stdout.getOutput());
     }
 
     @Test

--- a/src/test/java/org/apache/maven/shared/utils/cli/shell/CmdShellTest.java
+++ b/src/test/java/org/apache/maven/shared/utils/cli/shell/CmdShellTest.java
@@ -1,0 +1,98 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.maven.shared.utils.cli.shell;
+
+import java.util.List;
+
+import org.apache.maven.shared.utils.cli.Commandline;
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+/**
+ * The command line built here is a string, so these tests run on every platform. {@code Commandline} rewrites the
+ * path separators of the executable for the current platform, so the expected strings are built from
+ * {@code getExecutable()} rather than from the literal path.
+ */
+public class CmdShellTest {
+
+    private static Commandline commandline(String executable, String... arguments) {
+        Commandline commandline = new Commandline(new CmdShell());
+        commandline.setExecutable(executable);
+        for (String argument : arguments) {
+            commandline.createArg().setValue(argument);
+        }
+        return commandline;
+    }
+
+    private static String commandLine(Commandline commandline) {
+        List<String> lines = commandline.getShell().getShellCommandLine(commandline.getArguments());
+        assertEquals("cmd.exe", lines.get(0));
+        assertEquals("/X", lines.get(1));
+        assertEquals("/C", lines.get(2));
+        assertEquals(4, lines.size());
+        return lines.get(3);
+    }
+
+    @Test
+    public void plainItemsAreNotQuoted() {
+        assertEquals("\"mvn.cmd -B compile\"", commandLine(commandline("mvn.cmd", "-B", "compile")));
+    }
+
+    @Test
+    public void executableWithParenthesesIsQuoted() {
+        // MSHARED-832: C:\work\lol(1)\maven\bin\mvn.cmd
+        Commandline cl = commandline("C:\\work\\lol(1)\\maven\\bin\\mvn.cmd", "-B", "compile");
+        assertEquals("\"\"" + cl.getExecutable() + "\" -B compile\"", commandLine(cl));
+    }
+
+    @Test
+    public void executableWithSpaceIsQuoted() {
+        Commandline cl = commandline("C:\\Program Files\\maven\\bin\\mvn.cmd", "-B");
+        assertEquals("\"\"" + cl.getExecutable() + "\" -B\"", commandLine(cl));
+    }
+
+    @Test
+    public void argumentWithCmdSpecialCharactersIsQuoted() {
+        // MSHARED-765: a password containing &
+        assertEquals("\"jarsigner -storepass \"a&b\"\"", commandLine(commandline("jarsigner", "-storepass", "a&b")));
+        assertEquals(
+                "\"x \"a|b\" \"c<d\" \"e>f\" \"g^h\" \"i@j\" \"k l\"\"",
+                commandLine(commandline("x", "a|b", "c<d", "e>f", "g^h", "i@j", "k l")));
+    }
+
+    @Test
+    public void alreadyQuotedItemIsLeftAlone() {
+        assertEquals("\"x \"a b\"\"", commandLine(commandline("x", "\"a b\"")));
+    }
+
+    @Test
+    public void unconditionalQuotingQuotesEveryItem() {
+        Commandline cl = commandline("x", "plain");
+        cl.getShell().setUnconditionalQuoting(true);
+        assertEquals("\"\"x\" \"plain\"\"", commandLine(cl));
+    }
+
+    @Test
+    public void quotingCanBeDisabled() {
+        Commandline cl = commandline("x", "a&b");
+        cl.getShell().setQuotedArgumentsEnabled(false);
+        assertEquals("\"x a&b\"", commandLine(cl));
+    }
+}


### PR DESCRIPTION
`CmdShell` builds one `cmd.exe /X /C "<line>"` string and never quoted the items inside it, so an executable path with parentheses or an argument with `&` was parsed by `cmd.exe` as operators. This adds `CmdShell.quoteOneItem`: an item that contains whitespace or one of the characters `cmd.exe /?` lists as special (`& < > ( ) @ ^ |`) is wrapped in double quotes; an item already wrapped in double quotes is left alone; `setQuotedArgumentsEnabled(false)` and `setUnconditionalQuoting(true)` keep their meaning.

Two things differ from the earlier attempts (#40, MSHARED-851). The quoting is conditional on the documented character set rather than unconditional, and it is confined to `CmdShell`, so `BourneShell` is untouched. It also restores something master lost in ef89c5a (#369): before that commit `Shell.quoteOneItem` double-quoted items containing a space through `quoteAndEscape`, and 3.4.2 still ships that behaviour. `Shell.getQuotingTriggerChars` was the dead remainder of that mechanism and is removed here.

Two behaviour changes to be aware of:

- The `^&` workaround from #268 stops working. `^&` contains `&`, so it is now quoted, and `^` is literal inside quotes, so the program receives `^&`. Users who applied it must drop it.
- Under `-Djdk.lang.Process.allowAmbiguousCommands=false`, Java rejects a quoted argument that contains further quotes. Previously only caller-supplied inner quotes could trigger that; now any space or special character does. Default JVMs are unaffected.

`CmdShellTest` pins the string shape on every platform. Two tests in `CommandLineUtilsTest` run only on Windows and execute a real `cmd.exe`: `echo a&b` must print `"a&b"` rather than run `b`, and a script under a `lol(1)` directory must run. The three windows-latest CI jobs are the evidence for those.

Fixes #268, which also covers the parentheses case from #286.

Verified: `mvn -B verify` on JDK 17 (macOS) -> Tests run: 800, Failures: 0, Errors: 0, Skipped: 19; spotless clean; the Windows execution tests pass on all three windows-latest jobs (JDK 8, 21, 25).

*This change was created with AI assistance.*
