### PR TITLE
Add tag-template to release-drafter.yml

### DIFF
--- a/.github/release-drafter.yml
+++ b/.github/release-drafter.yml
@@ -16,3 +16,4 @@
 # under the License.
 
 _extends: maven-gh-actions-shared
+tag-template: maven-shared-utils-$RESOLVED_VERSION


### PR DESCRIPTION
Shared config defaults to `v$RESOLVED_VERSION`, but this project tags
releases as `maven-shared-utils-<version>`.